### PR TITLE
enrogue episode in audiofeed

### DIFF
--- a/blog/podcasts/en-rogue/2025-04-06-en-rogue-4.mdx
+++ b/blog/podcasts/en-rogue/2025-04-06-en-rogue-4.mdx
@@ -3,6 +3,7 @@ slug: en-rogue-4
 title: 'En Rogue #04'
 authors: [simon,adrian,yollum]
 tags: [podcast,en-rogue,simon,yollum,adrian]
+date: 2025-04-07
 image: /img/enrogue.jpg
 draft: false
 ---

--- a/static/audiofeed.yaml
+++ b/static/audiofeed.yaml
@@ -1,3 +1,13 @@
+- title: 'En Rogue #04 – Der Wald hasst uns'
+  date: 2025-04-07T09:00
+  image: https://raw.githubusercontent.com/LucaNerlich/m10z/main/static/img/enrogue.jpg
+  description: |2-
+                  Fast pünktlich nach einem halben Jahr tauchen Simon, Adrian und Jan in der neuesten Podcast-Episode von EnRogue tief in den feindlichen Wald des Roguelike-City-Builders „Against the Storm“ ein, nur um festzustellen, dass es fast eine größere Herausforderung die Komplexität des Spiels runterzubrechen als einen Run zu überleben. 
+                  Sie stoßen immer wieder an ihre Grenzen die Übersicht über Feindlichkeits- und Wettersysteme, Produktionsketten oder sich darauf zu einigen wie viele Spezien es überhaupt gibt. 
+                  Hört euch die Folge dazu an und seid geduldiger als die Königin. 
+  seconds: '01:09:57'
+  blogpost: https://m10z.de/en-rogue-4
+  url: https://m10z.picnotes.de/EnRogue/EnRogue_004.mp3
 - title: 'Spezial: Videospiele und Verantwortung – Games, Politik, Krisen (mit Christian Schiffer)'
   date: 2025-03-08T16:00
   image: https://raw.githubusercontent.com/LucaNerlich/m10z/main/static/img/SpezialChristian_NeuesLogoMitChristian.png


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Aktualisiertes Veröffentlichungsdatum in den Podcast-Metadaten.
  - Neue Podcast-Folge "En Rogue #04 – Der Wald hasst uns" hinzugefügt, inklusive Details wie Datum, Dauer, Bild, Beschreibung, Blog-Link und Audio-URL.
  - Eine ältere Podcast-Folge wurde entfernt, um das Angebot zu optimieren.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->