### PR TITLE
cc2

### DIFF
--- a/blog/podcasts/comiccast/2025-08-24-cc-2.mdx
+++ b/blog/podcasts/comiccast/2025-08-24-cc-2.mdx
@@ -1,6 +1,6 @@
 ---
-slug: cc-12
-title: 'Der M10Z Comic Cast 2'
+slug: cc-2
+title: 'Der M10Z Comic Cast 2 - Ein Videospielsachcomic'
 authors: [lipardus,simon,tilmobaxter]
 tags: [podcast,comiccast,lipardus,simon,tilmobaxter]
 image: /img/formate/banner/comic-cast.jpg
@@ -19,7 +19,8 @@ Sach mal, Sachcomics...sacht dir das was?
 
 Moin meine Freund:innen,
 
-zum zweiten mal könnt ihr unseren Comic Cast hören und dieses mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über Gaming – Eine Pixel-Zeitreise von Autor Jean Zeid und Zeichnerin Émilie Rouge.
+zum zweiten mal könnt ihr unseren Comic Cast hören.
+Dieses mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über "Gaming – Eine Pixel-Zeitreise" von Autor Jean Zeid und Zeichnerin Émilie Rouge.
 Wir finden raus ob der Band als Sachcomic hält was er verspricht, ob wir andere oder gar bessere Beispiele kennen und wem wir die gezeichnete Spielereise empfehlen würden.
 Darüber hinaus bringt Simon euch den Comic "Die Einladung" mit, Edgar empfiehlt "Understanding Comics" und ich möchte euch die Serie "Time Before Time" ans Herz legen.
 Wenn ihr Anmerkungen habt, eigene momentane Lieblingscomics oder einfach mal Hallo sagen wollt, tut das doch im [Forum](https://community.wasted.de). 
@@ -30,12 +31,12 @@ Til, Simon und Edgar
 
 In dieser Folge besprochene Werke:
 
-- [Gaming – Eine Pixel-Zeitreise] (https://www.carlsen.de/hardcover/gaming-eine-pixel-zeitreise/978-3-551-80598-0) (Jean Zeid, Émilie Rouge; Carlsen Comics, 2025)
+- [Gaming – Eine Pixel-Zeitreise](https://www.carlsen.de/hardcover/gaming-eine-pixel-zeitreise/978-3-551-80598-0) (Jean Zeid, Émilie Rouge; Carlsen Comics, 2025)
 - [Games](https://www.splitter-verlag.de/games-fluechtenden-aus-afghanistan.html) (Patrick Oberholzer; Splitter Verlag 2023)
 - [Zwei weibliche Halbakte](https://reprodukt.com/products/zwei-weibliche-halbakte) (Luz; Reprodukt Verlag 2025)
 - [Die Einladung](https://www.splitter-verlag.de/die-einladung.html) (Jim, Mermoux; Splitter Verlag 2012)
-- [Understanding Comics] (https://scottmccloud.com/2-print/1-uc/) (Scott Mccloud; diverse Verlage 1994)
-- [Time Before Time] (https://imagecomics.com/comics/series/time-before-time) (Rory McConville, Joe Palmer, Declan Shalvey; Image Comics 2021)
+- [Understanding Comics](https://scottmccloud.com/2-print/1-uc/) (Scott Mccloud; diverse Verlage 1994)
+- [Time Before Time](https://imagecomics.com/comics/series/time-before-time) (Rory McConville, Joe Palmer, Declan Shalvey; Image Comics 2021)
 
 
 <ReactPlayer

--- a/blog/podcasts/comiccast/2025-08-24-cc-2.mdx
+++ b/blog/podcasts/comiccast/2025-08-24-cc-2.mdx
@@ -1,0 +1,46 @@
+---
+slug: cc-12
+title: 'Der M10Z Comic Cast 2'
+authors: [lipardus,simon,tilmobaxter]
+tags: [podcast,comiccast,lipardus,simon,tilmobaxter]
+image: /img/formate/banner/comic-cast.jpg
+date: 2025-08-24
+draft: false
+---
+
+import Image from '@theme/IdealImage'
+import ReactPlayer from 'react-player'
+
+Sach mal, Sachcomics...sacht dir das was?
+
+<Image style={{width: '100%'}} img={require('/static/img/formate/banner/comic-cast.jpg')} />
+
+<!--truncate-->
+
+Moin meine Freund:innen,
+
+zum zweiten mal könnt ihr unseren Comic Cast hören und dieses mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über Gaming – Eine Pixel-Zeitreise von Autor Jean Zeid und Zeichnerin Émilie Rouge.
+Wir finden raus ob der Band als Sachcomic hält was er verspricht, ob wir andere oder gar bessere Beispiele kennen und wem wir die gezeichnete Spielereise empfehlen würden.
+Darüber hinaus bringt Simon euch den Comic "Die Einladung" mit, Edgar empfiehlt "Understanding Comics" und ich möchte euch die Serie "Time Before Time" ans Herz legen.
+Wenn ihr Anmerkungen habt, eigene momentane Lieblingscomics oder einfach mal Hallo sagen wollt, tut das doch im [Forum](https://community.wasted.de). 
+
+Ganz liebe Grüße,
+
+Til, Simon und Edgar
+
+In dieser Folge besprochene Werke:
+
+- [Gaming – Eine Pixel-Zeitreise] (https://www.carlsen.de/hardcover/gaming-eine-pixel-zeitreise/978-3-551-80598-0) (Jean Zeid, Émilie Rouge; Carlsen Comics, 2025)
+- [Games](https://www.splitter-verlag.de/games-fluechtenden-aus-afghanistan.html) (Patrick Oberholzer; Splitter Verlag 2023)
+- [Zwei weibliche Halbakte](https://reprodukt.com/products/zwei-weibliche-halbakte) (Luz; Reprodukt Verlag 2025)
+- [Die Einladung](https://www.splitter-verlag.de/die-einladung.html) (Jim, Mermoux; Splitter Verlag 2012)
+- [Understanding Comics] (https://scottmccloud.com/2-print/1-uc/) (Scott Mccloud; diverse Verlage 1994)
+- [Time Before Time] (https://imagecomics.com/comics/series/time-before-time) (Rory McConville, Joe Palmer, Declan Shalvey; Image Comics 2021)
+
+
+<ReactPlayer
+    width="100%"
+    height="50px"
+    controls
+    src='https://m10z.picnotes.de/ComicCast/ComicCast_002.mp3'
+/>

--- a/blog/podcasts/comiccast/2025-08-27-cc-2.mdx
+++ b/blog/podcasts/comiccast/2025-08-27-cc-2.mdx
@@ -4,7 +4,7 @@ title: 'Der M10Z Comic Cast 2 - Ein Videospielsachcomic'
 authors: [lipardus,simon,tilmobaxter]
 tags: [podcast,comiccast,lipardus,simon,tilmobaxter]
 image: /img/formate/banner/comic-cast.jpg
-date: 2025-08-24
+date: 2025-08-27   
 draft: false
 ---
 

--- a/blog/podcasts/comiccast/2025-08-27-cc-2.mdx
+++ b/blog/podcasts/comiccast/2025-08-27-cc-2.mdx
@@ -19,17 +19,17 @@ Sach mal, Sachcomics...sacht dir das was?
 
 Moin meine Freund:innen,
 
-zum zweiten mal könnt ihr unseren Comic Cast hören.
-Dieses mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über "Gaming – Eine Pixel-Zeitreise" von Autor Jean Zeid und Zeichnerin Émilie Rouge.
-Wir finden raus ob der Band als Sachcomic hält was er verspricht, ob wir andere oder gar bessere Beispiele kennen und wem wir die gezeichnete Spielereise empfehlen würden.
-Darüber hinaus bringt Simon euch den Comic "Die Einladung" mit, Edgar empfiehlt "Understanding Comics" und ich möchte euch die Serie "Time Before Time" ans Herz legen.
-Wenn ihr Anmerkungen habt, eigene momentane Lieblingscomics oder einfach mal Hallo sagen wollt, tut das doch im [Forum](https://community.wasted.de). 
+hier kommt die Nummer 2 unseres Comic Casts.  
+Dieses Mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über "Gaming – Eine Pixel-Zeitreise" von Autor Jean Zeid und Zeichnerin Émilie Rouge.  
+Wir finden heraus, ob der Band als Sachcomic hält was er verspricht, ob wir andere oder gar bessere Beispiele kennen und wem wir die gezeichnete Spielereise empfehlen würden.  
+Darüber hinaus bringt Simon euch den Comic "Die Einladung" mit, Edgar empfiehlt "Understanding Comics" und ich möchte euch die Serie "Time Before Time" ans Herz legen.  
+Wenn ihr Anmerkungen habt, eigene momentane Lieblingscomics oder einfach mal Hallo sagen wollt, tut das doch im [Forum](https://community.wasted.de).   
 
-Ganz liebe Grüße,
+Ganz liebe Grüße,  
+  
+Til, Simon und Edgar     
 
-Til, Simon und Edgar
-
-In dieser Folge besprochene Werke:
+In dieser Folge besprochene Werke:  
 
 - [Gaming – Eine Pixel-Zeitreise](https://www.carlsen.de/hardcover/gaming-eine-pixel-zeitreise/978-3-551-80598-0) (Jean Zeid, Émilie Rouge; Carlsen Comics, 2025)
 - [Games](https://www.splitter-verlag.de/games-fluechtenden-aus-afghanistan.html) (Patrick Oberholzer; Splitter Verlag 2023)

--- a/static/audiofeed.yaml
+++ b/static/audiofeed.yaml
@@ -1,4 +1,4 @@
--title: 'Der M10Z Comic Cast 02 - Ein Videospielsachcomic'
+- title: 'Der M10Z Comic Cast 02 - Ein Videospielsachcomic'
   date: 2025-06-23T15:00
   image: https://raw.githubusercontent.com/LucaNerlich/m10z/main/static/img/formate/cover/comic-cast.jpg
   description: |2-

--- a/static/audiofeed.yaml
+++ b/static/audiofeed.yaml
@@ -4,9 +4,9 @@
   description: |2-
                 Moin meine Freund:innen,
 
-                zum zweiten mal könnt ihr unseren Comic Cast hören. 
-                Dieses mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über "Gaming – Eine Pixel-Zeitreise" von Autor Jean Zeid und Zeichnerin Émilie Rouge.
-                Wir finden raus ob der Band als Sachcomic hält was er verspricht, ob wir andere oder gar bessere Beispiele kennen und wem wir die gezeichnete Spielereise empfehlen würden.
+                hier kommt die Nummer 2 unserers Comic Casts. 
+                Dieses Mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über "Gaming – Eine Pixel-Zeitreise" von Autor Jean Zeid und Zeichnerin Émilie Rouge.
+                Wir finden heraus, ob der Band als Sachcomic hält was er verspricht, ob wir andere oder gar bessere Beispiele kennen und wem wir die gezeichnete Spielereise empfehlen würden.
                 Darüber hinaus bringt Simon euch den Comic "Die Einladung" mit, Edgar empfiehlt "Understanding Comics" und ich möchte euch die Serie "Time Before Time" ans Herz legen.
                 Wenn ihr Anmerkungen habt, eigene momentane Lieblingscomics oder einfach mal Hallo sagen wollt, tut das doch im [Forum](https://community.wasted.de). 
   

--- a/static/audiofeed.yaml
+++ b/static/audiofeed.yaml
@@ -1,3 +1,28 @@
+-title: 'Der M10Z Comic Cast 02 - Ein Videospielsachcomic'
+  date: 2025-06-23T15:00
+  image: https://raw.githubusercontent.com/LucaNerlich/m10z/main/static/img/formate/cover/comic-cast.jpg
+  description: |2-
+                Moin meine Freund:innen,
+
+                zum zweiten mal könnt ihr unseren Comic Cast hören. 
+                Dieses mal haben wir uns das Thema Sachcomic als Aufhänger genommen und sprechen über "Gaming – Eine Pixel-Zeitreise" von Autor Jean Zeid und Zeichnerin Émilie Rouge.
+                Wir finden raus ob der Band als Sachcomic hält was er verspricht, ob wir andere oder gar bessere Beispiele kennen und wem wir die gezeichnete Spielereise empfehlen würden.
+                Darüber hinaus bringt Simon euch den Comic "Die Einladung" mit, Edgar empfiehlt "Understanding Comics" und ich möchte euch die Serie "Time Before Time" ans Herz legen.
+                Wenn ihr Anmerkungen habt, eigene momentane Lieblingscomics oder einfach mal Hallo sagen wollt, tut das doch im [Forum](https://community.wasted.de). 
+                
+                Ganz liebe Grüße,
+                Til, Simon und Edgar
+                
+                In dieser Folge besprochene Werke:
+                - [Gaming – Eine Pixel-Zeitreise](https://www.carlsen.de/hardcover/gaming-eine-pixel-zeitreise/978-3-551-80598-0) (Jean Zeid, Émilie Rouge; Carlsen Comics, 2025)
+                - [Games](https://www.splitter-verlag.de/games-fluechtenden-aus-afghanistan.html) (Patrick Oberholzer; Splitter Verlag 2023)
+                - [Zwei weibliche Halbakte](https://reprodukt.com/products/zwei-weibliche-halbakte) (Luz; Reprodukt Verlag 2025)
+                - [Die Einladung](https://www.splitter-verlag.de/die-einladung.html) (Jim, Mermoux; Splitter Verlag 2012)
+                - [Understanding Comics](https://scottmccloud.com/2-print/1-uc/) (Scott Mccloud; diverse Verlage 1994)
+                - [Time Before Time](https://imagecomics.com/comics/series/time-before-time) (Rory McConville, Joe Palmer, Declan Shalvey; Image Comics 2021)
+  seconds: 3780
+  blogpost: https://m10z.de/cc-2
+  url: https://m10z.picnotes.de/ComicCast/ComicCast_002.mp3
 - title: 'Fundbüro #16 – Auf vier Rädern in die Cyberpunk-Apokalypse | Motorhead und Hard Truck: Apocalypse'
   date: 2025-08-10T08:00
   image: https://raw.githubusercontent.com/LucaNerlich/m10z/main/static/img/formate/cover/fundbuero.jpg

--- a/static/audiofeed.yaml
+++ b/static/audiofeed.yaml
@@ -1,5 +1,5 @@
 - title: 'Der M10Z Comic Cast 02 - Ein Videospielsachcomic'
-  date: 2025-06-23T15:00
+  date: 2025-08-27T15:00  
   image: https://raw.githubusercontent.com/LucaNerlich/m10z/main/static/img/formate/cover/comic-cast.jpg
   description: |2-
                 Moin meine Freund:innen,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Neue Features**
  - Neuer Podcast: „Der M10Z Comic Cast 02 – Ein Videospielsachcomic“ mit ausführlichen Shownotes, Bannerbild, eingebettetem Audioplayer und direktem MP3-Stream. Verfügbar ab 27.08.2025.

- **Chores**
  - Audio-Feed aktualisiert: Comic-Cast-Folge hinzugefügt; zuvor publizierte Folgen „Pixelplausch #04“ und „Fundbüro #16“ entfernt; zahlreiche redaktionelle Text- und Formatkorrekturen (Whitespace/Typo-Anpassungen).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->