### PR TITLE
fix(m12g): Titelträger badges for März 2026 (name normalization + ties)

### DIFF
--- a/frontend/src/components/M12GMonthCard.tsx
+++ b/frontend/src/components/M12GMonthCard.tsx
@@ -9,6 +9,7 @@ type M12GMonthCardProps = {
 
 export function M12GMonthCard({month}: M12GMonthCardProps) {
     const {winners} = month;
+    const titleDefenderNames = new Set(month.titleDefenders);
     const winnerNames = new Set(winners.map((w) => w.name));
     const nonWinners = month.games.filter((game) => !winnerNames.has(game.name));
 
@@ -29,7 +30,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                         <li className={styles.winnerGroup}>
                             <span className={styles.winnerLabel}>Sieger</span>
                             {winners.map((game) => {
-                                const isTitleDefender = game.name === month.titleDefender;
+                                const isTitleDefender = titleDefenderNames.has(game.name);
                                 return (
                                     <div key={`${game.name}-${game.link}`}
                                         className={styles.winnerItem}>
@@ -53,7 +54,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                         </li>
                     ) : null}
                     {nonWinners.map((game) => {
-                        const isTitleDefender = game.name === month.titleDefender;
+                        const isTitleDefender = titleDefenderNames.has(game.name);
                         return (
                             <li key={`${game.name}-${game.link}`}
                                 className={styles.gameItem}>

--- a/frontend/src/lib/m12g/m12gData.ts
+++ b/frontend/src/lib/m12g/m12gData.ts
@@ -11,6 +11,16 @@ type Frontmatter = {
 
 const MONTH_FILE_REGEX = /^\d{4}-\d{2}\.md$/;
 const LIST_ITEM_REGEX = /^\s*[*-]\s+\[([^\]]+)\]\(([^)]+)\)(?:\s+(\d+))?\s*$/;
+const TITLE_DEFENDER_NAME_SUFFIX = ' (Titelträger)';
+
+/** Strips manual "(Titelträger)" hints from markdown link text so names match across months. */
+function normalizeM12GGameName(raw: string): string {
+    const trimmed = raw.trim();
+    if (trimmed.endsWith(TITLE_DEFENDER_NAME_SUFFIX)) {
+        return trimmed.slice(0, -TITLE_DEFENDER_NAME_SUFFIX.length).trim();
+    }
+    return trimmed;
+}
 
 function parseFrontmatter(rawContent: string): {frontmatter: Frontmatter; body: string} {
     if (!rawContent.startsWith('---')) {
@@ -59,7 +69,11 @@ function parseGamesFromBody(body: string): M12GGame[] {
         if (!match) continue;
         const [, name, link, voteValue] = match;
         const votes = voteValue ? Number.parseInt(voteValue, 10) : 0;
-        games.push({name: name.trim(), link: link.trim(), votes: Number.isNaN(votes) ? 0 : votes});
+        games.push({
+            name: normalizeM12GGameName(name),
+            link: link.trim(),
+            votes: Number.isNaN(votes) ? 0 : votes,
+        });
     }
 
     games.sort((a, b) => b.votes - a.votes);
@@ -90,7 +104,7 @@ async function loadMonthFromFile(filePath: string, monthId: string): Promise<M12
         return {
             ...month,
             winners: computeWinners(games),
-            titleDefender: null,
+            titleDefenders: [],
         };
     } catch {
         return null;
@@ -118,6 +132,7 @@ async function loadM12GMonths(): Promise<M12GMonthWithWinner[]> {
 
 // Marks games that won the previous month and were nominated again this month.
 // A "title defender" is the returning champion — shown in the UI to highlight repeat contenders.
+// After a tied month, every co-winner can be a defender in the next month.
 function assignTitleDefenders(months: M12GMonthWithWinner[]): void {
     const chronological = [...months].sort((a, b) => a.month.localeCompare(b.month));
     for (let i = 1; i < chronological.length; i++) {
@@ -125,9 +140,9 @@ function assignTitleDefenders(months: M12GMonthWithWinner[]): void {
         if (previousWinners.length === 0) continue;
         const previousWinnerNames = new Set(previousWinners.map((w) => w.name));
         const current = chronological[i];
-        const defender = current.games.find((game) => previousWinnerNames.has(game.name));
-        if (defender) {
-            current.titleDefender = defender.name;
+        const defenders = current.games.filter((game) => previousWinnerNames.has(game.name));
+        if (defenders.length > 0) {
+            current.titleDefenders = defenders.map((game) => game.name);
         }
     }
 }

--- a/frontend/src/lib/m12g/types.ts
+++ b/frontend/src/lib/m12g/types.ts
@@ -13,7 +13,8 @@ export interface M12GMonth {
 
 export interface M12GMonthWithWinner extends M12GMonth {
     winners: M12GGame[];
-    titleDefender: string | null;
+    /** Normalized game names that won the prior month and are nominated again this month (can be several after a tie). */
+    titleDefenders: string[];
 }
 
 export interface M12GOverview {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The März 2026 dataset marks Cairn and Mewgenics as `(Titelträger)` in the markdown link text. The parser kept that suffix in `game.name`, while the title-defender logic compared against plain names from the previous month (`Cairn`, `Mewgenics`), so the badge never matched.

Additionally, Februar 2026 had tied winners at 6 votes each; the previous implementation only recorded a single defender.

## Changes

- Strip the ` (Titelträger)` suffix when parsing list items so display names and comparisons stay consistent.
- Replace `titleDefender: string | null` with `titleDefenders: string[]` so every co-winner from the prior month can get the badge when nominated again.

## Verification

- `pnpm run build` in `frontend/` compiles TypeScript successfully; full build may require `STRAPI_URL` in the environment for page data collection (pre-existing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca6db7c7-a504-47eb-919d-ee8ac28bcda5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca6db7c7-a504-47eb-919d-ee8ac28bcda5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

