### PR TITLE
fix(frontend): changelog page path and deployment tracing

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Version number in the site footer (next to the font and theme pickers) linking to a new `/changelog` page that renders this CHANGELOG; the footer label and the page's metadata both read from `package.json` so future releases update both automatically
 
+### Fixed
+- `/changelog` loads `CHANGELOG.md` reliably in CI and cloud deploys: `getChangelogMarkdown()` checks both the app root and `frontend/CHANGELOG.md` when `process.cwd()` is the monorepo root, and `outputFileTracingIncludes` in `next.config.ts` forces the file into the traced server output so Turbopack/serverless bundles no longer omit it
+
 ## [1.4.0] - 2026-05-10
 
 ### Added

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -1,6 +1,5 @@
-import {readFile} from 'node:fs/promises';
-import path from 'node:path';
 import {type Metadata} from 'next';
+import {getChangelogMarkdown} from '@/src/lib/changelogMarkdown';
 import {Markdown} from '@/src/lib/markdown/Markdown';
 import {buildStaticListMetadata} from '@/src/lib/metadata/staticListMetadata';
 import {version as appVersion} from '../../package.json';
@@ -13,7 +12,7 @@ export const metadata: Metadata = buildStaticListMetadata({
 });
 
 export default async function ChangelogPage() {
-    const markdown = await readFile(path.join(process.cwd(), 'CHANGELOG.md'), 'utf-8');
+    const markdown = await getChangelogMarkdown();
     return (
         <div data-list-page>
             <Markdown markdown={markdown} />

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,6 +4,9 @@ import {ALLOWED_IMAGE_HOSTNAMES, getRemotePatterns} from './src/lib/image/hostna
 const isProd = process.env.NODE_ENV === 'production';
 
 const nextConfig: NextConfig = {
+    outputFileTracingIncludes: {
+        '/changelog': ['./CHANGELOG.md'],
+    },
     ...(isProd
         ? {}
         : {

--- a/frontend/src/lib/changelogMarkdown.ts
+++ b/frontend/src/lib/changelogMarkdown.ts
@@ -1,0 +1,16 @@
+import {existsSync} from 'node:fs';
+import {readFile} from 'node:fs/promises';
+import path from 'node:path';
+
+export async function getChangelogMarkdown(): Promise<string> {
+    const candidates = [
+        path.join(process.cwd(), 'CHANGELOG.md'),
+        path.join(process.cwd(), 'frontend', 'CHANGELOG.md'),
+    ];
+    for (const filePath of candidates) {
+        if (existsSync(filePath)) {
+            return readFile(filePath, 'utf-8');
+        }
+    }
+    throw new Error('CHANGELOG.md was not found');
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `/changelog` page read `CHANGELOG.md` with `path.join(process.cwd(), 'CHANGELOG.md')`. That breaks when the build or runtime working directory is the monorepo root instead of `frontend/`, and Turbopack output tracing can omit the file from serverless or standalone bundles because the path is not statically obvious.

## Changes

- Add `getChangelogMarkdown()` in `src/lib/changelogMarkdown.ts` that tries `CHANGELOG.md` next to `process.cwd()` and `frontend/CHANGELOG.md` under the cwd.
- Register `outputFileTracingIncludes` for `/changelog` so `./CHANGELOG.md` is always included in the traced output.
- Document the fix under `[1.5.0]` in `frontend/CHANGELOG.md`.

## Verification

- `npx tsc --noEmit` in `frontend/` passes.
- Full `pnpm run build` was not completed in this environment because unrelated routes (e.g. sitemap) require Strapi/network at build time.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c28ee52d-bbc1-4147-9e37-a1ce19b08c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c28ee52d-bbc1-4147-9e37-a1ce19b08c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

