### PR TITLE
improve: harden feed cache, preview routes, RSS links, API tests, backend strict mode

### DIFF
--- a/backend/config/admin.ts
+++ b/backend/config/admin.ts
@@ -1,4 +1,4 @@
-export default ({env}) => {
+export default ({env}: any) => {
     const clientUrl = env('CLIENT_URL');
 
     return {
@@ -41,7 +41,7 @@ export default ({env}) => {
                 allowedOrigins: [clientUrl, 'https://m10z.de', 'http://localhost:3000'].filter(Boolean),
                 // Maps Strapi content UIDs to frontend preview routes.
                 // Only articles and podcasts support preview; other types return null (no preview link).
-                async handler(uid, {documentId, locale, status}) {
+                async handler(uid: any, {documentId, locale, status}: any) {
                     if (!clientUrl) return null;
                     if (!documentId) return null;
 

--- a/backend/config/database.ts
+++ b/backend/config/database.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-export default ({env}) => {
+export default ({env}: any) => {
     const client = env('DATABASE_CLIENT', 'sqlite');
 
     const connections = {
@@ -63,7 +63,7 @@ export default ({env}) => {
     return {
         connection: {
             client,
-            ...connections[client],
+            ...(connections as any)[client],
             /**
              * Database connection pool configuration:
              *

--- a/backend/config/server.ts
+++ b/backend/config/server.ts
@@ -33,7 +33,7 @@ export function configureServerTimeouts(server: Server): void {
     server.requestTimeout = 120000; // 120 seconds
 }
 
-export default ({env}) => ({
+export default ({env}: any) => ({
     host: env('HOST', '0.0.0.0'),
     port: env.int('PORT', 1337),
     app: {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -78,7 +78,7 @@ export default {
         // 2. durationMiddleware (runs before save)
         // 3. cacheInvalidationMiddleware (runs after save)
 
-        strapi.documents.use(async (context, next) => {
+        strapi.documents.use(async (context: any, next: any) => {
             // Pass strapi to context params so middleware can access it
             if (!context.params) {
                 context.params = {};
@@ -87,7 +87,7 @@ export default {
             return wordCountMiddleware(context, next);
         });
 
-        strapi.documents.use(async (context, next) => {
+        strapi.documents.use(async (context: any, next: any) => {
             // Pass strapi to context params so middleware can access it
             if (!context.params) {
                 context.params = {};
@@ -96,7 +96,7 @@ export default {
             return durationMiddleware(context, next);
         });
 
-        strapi.documents.use(async (context, next) => {
+        strapi.documents.use(async (context: any, next: any) => {
             // Pass strapi to context params so middleware can access it
             if (!context.params) {
                 context.params = {};
@@ -220,7 +220,7 @@ export default {
                 if (strapi.server?.httpServer) {
                     strapi.log.info('Closing HTTP server...');
                     await new Promise<void>((resolve, reject) => {
-                        strapi.server.httpServer.close((err) => {
+                        strapi.server.httpServer.close((err: unknown) => {
                             if (err) {
                                 strapi.log.error('Error closing HTTP server:', err);
                                 reject(err);

--- a/backend/src/middlewares/wordCount.ts
+++ b/backend/src/middlewares/wordCount.ts
@@ -288,6 +288,7 @@ export async function wordCountMiddleware(
             if (data) {
                 // Get strapi instance from context
                 const strapiInstance = context.params?.strapi;
+                if (!strapiInstance) return next();
                 // Determine contentType based on uid
                 const contentType = context.contentType?.uid === 'api::article.article' ? 'article' : 'podcast';
                 await extractWordCount(strapiInstance, data, contentType);

--- a/backend/src/services/contentInvalidationLifecycles.test.ts
+++ b/backend/src/services/contentInvalidationLifecycles.test.ts
@@ -1,0 +1,66 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+vi.mock('./asyncCacheInvalidationQueue', () => ({
+    queueCacheInvalidation: vi.fn(),
+}));
+
+vi.mock('./asyncSearchIndexQueue', () => ({
+    queueSearchIndexRebuild: vi.fn(),
+}));
+
+import {queueCacheInvalidation} from './asyncCacheInvalidationQueue';
+import {queueSearchIndexRebuild} from './asyncSearchIndexQueue';
+import {createContentInvalidationLifecycles} from './contentInvalidationLifecycles';
+
+const fakeStrapi = {log: {info: vi.fn(), warn: vi.fn()}};
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('createContentInvalidationLifecycles', () => {
+    test('returns an empty object for an unknown UID', () => {
+        const handlers = createContentInvalidationLifecycles('api::unknown.unknown');
+        expect(handlers).toEqual({});
+    });
+
+    test('returns handlers for every event defined in the manifest for api::article.article', () => {
+        const handlers = createContentInvalidationLifecycles('api::article.article');
+        const keys = Object.keys(handlers).sort();
+        expect(keys).toEqual(['afterCreate', 'afterDelete', 'afterUpdate']);
+    });
+
+    test('invoking a handler calls queueCacheInvalidation', () => {
+        vi.stubGlobal('strapi', fakeStrapi);
+        const handlers = createContentInvalidationLifecycles('api::article.article');
+        handlers['afterCreate']?.(undefined);
+        expect(queueCacheInvalidation).toHaveBeenCalled();
+    });
+
+    test('invoking a handler also calls queueSearchIndexRebuild for search-index UIDs', () => {
+        vi.stubGlobal('strapi', fakeStrapi);
+        const handlers = createContentInvalidationLifecycles('api::article.article');
+        handlers['afterCreate']?.(undefined);
+        expect(queueSearchIndexRebuild).toHaveBeenCalled();
+    });
+
+    test('does not call queueSearchIndexRebuild for non-search-index UIDs', () => {
+        // api::imprint.imprint is not in SEARCH_INDEX_REBUILD_UIDS
+        vi.stubGlobal('strapi', fakeStrapi);
+        const handlers = createContentInvalidationLifecycles('api::imprint.imprint');
+        handlers['afterUpdate']?.(undefined);
+        expect(queueCacheInvalidation).toHaveBeenCalled();
+        expect(queueSearchIndexRebuild).not.toHaveBeenCalled();
+    });
+
+    test('invoking a handler passes null to queueCacheInvalidation when strapi global is absent', () => {
+        // Do not stub strapi — it should be undefined in the test environment.
+        const handlers = createContentInvalidationLifecycles('api::article.article');
+        handlers['afterCreate']?.(undefined);
+        expect(queueCacheInvalidation).toHaveBeenCalledWith(
+            expect.any(String),
+            null,
+        );
+    });
+});

--- a/backend/src/services/contentInvalidationLifecycles.ts
+++ b/backend/src/services/contentInvalidationLifecycles.ts
@@ -14,7 +14,10 @@ type StrapiGlobal = {
     };
 };
 
-function runInvalidation(uid: string, event: StrapiLifecycleEvent, strapi: StrapiGlobal): void {
+// Strapi sets this global during application bootstrap.
+declare const strapi: StrapiGlobal | undefined;
+
+function runInvalidation(uid: string, event: StrapiLifecycleEvent, strapi: StrapiGlobal | null): void {
     const targets = LIFECYCLE_INVALIDATION[uid]?.[event];
     if (!targets) return;
 
@@ -37,7 +40,8 @@ export function createContentInvalidationLifecycles(uid: string): Record<string,
     const handlers: Record<string, (event: unknown) => void> = {};
     for (const event of Object.keys(config) as StrapiLifecycleEvent[]) {
         handlers[event] = () => {
-            runInvalidation(uid, event, strapi);
+            // eslint-disable-next-line no-undef
+            runInvalidation(uid, event, typeof strapi !== 'undefined' ? strapi : null);
         };
     }
     return handlers;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,7 +4,7 @@
         "moduleResolution": "Node",
         "lib": ["ES2020"],
         "target": "ES2019",
-        "strict": false,
+        "strict": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "incremental": true,

--- a/frontend/app/api/[target]/invalidate/route.test.ts
+++ b/frontend/app/api/[target]/invalidate/route.test.ts
@@ -1,0 +1,24 @@
+import {describe, expect, test, vi} from 'vitest';
+
+const {handleInvalidation} = vi.hoisted(() => ({
+    handleInvalidation: vi.fn(),
+}));
+
+vi.mock('@/src/lib/cache/handleInvalidation', () => ({handleInvalidation}));
+
+import {POST} from './route';
+
+describe('POST /api/[target]/invalidate', () => {
+    test('delegates to handleInvalidation with the resolved target param and returns its response', async () => {
+        const mockResponse = new Response('ok', {status: 200});
+        handleInvalidation.mockResolvedValue(mockResponse);
+
+        const request = new Request('https://m10z.de/api/article/invalidate', {method: 'POST'});
+        const params = Promise.resolve({target: 'article'});
+
+        const result = await POST(request, {params});
+
+        expect(handleInvalidation).toHaveBeenCalledWith(request, 'article');
+        expect(result).toBe(mockResponse);
+    });
+});

--- a/frontend/app/api/articlefeed/route.test.ts
+++ b/frontend/app/api/articlefeed/route.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, test, vi} from 'vitest';
+
+const {buildArticleFeedResponse} = vi.hoisted(() => ({
+    buildArticleFeedResponse: vi.fn(),
+}));
+
+vi.mock('@/src/lib/rss/articleFeedRouteHandler', () => ({
+    buildArticleFeedResponse,
+    getSchedulerState: vi.fn().mockReturnValue({}),
+}));
+
+import {GET} from './route';
+
+describe('GET /api/articlefeed', () => {
+    test('delegates to buildArticleFeedResponse with the request and returns the response', async () => {
+        const mockResponse = new Response('<rss/>', {status: 200, headers: {'Content-Type': 'application/rss+xml'}});
+        buildArticleFeedResponse.mockResolvedValue(mockResponse);
+
+        const request = new Request('https://m10z.de/api/articlefeed', {method: 'GET'});
+        const result = await GET(request);
+
+        expect(buildArticleFeedResponse).toHaveBeenCalledWith(request);
+        expect(result).toBe(mockResponse);
+    });
+});

--- a/frontend/app/api/diagnostics/route.test.ts
+++ b/frontend/app/api/diagnostics/route.test.ts
@@ -1,0 +1,80 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+const {verifySecret, checkRateLimit, getRecentDiagnosticEvents, getAudioFeedRuntimeState, getSchedulerState, getClientIp} =
+    vi.hoisted(() => ({
+        verifySecret: vi.fn(),
+        checkRateLimit: vi.fn(),
+        getRecentDiagnosticEvents: vi.fn().mockReturnValue([]),
+        getAudioFeedRuntimeState: vi.fn().mockReturnValue({}),
+        getSchedulerState: vi.fn().mockReturnValue({}),
+        getClientIp: vi.fn().mockReturnValue('127.0.0.1'),
+    }));
+
+vi.mock('@/src/lib/security/verifySecret', () => ({verifySecret}));
+vi.mock('@/src/lib/security/rateLimit', () => ({checkRateLimit}));
+vi.mock('@/src/lib/diagnostics/runtimeDiagnostics', () => ({getRecentDiagnosticEvents}));
+vi.mock('@/src/lib/rss/audioFeedRouteHandler', () => ({getAudioFeedRuntimeState}));
+vi.mock('@/src/lib/rss/articleFeedRouteHandler', () => ({
+    getSchedulerState,
+    buildArticleFeedResponse: vi.fn(),
+}));
+vi.mock('@/src/lib/net/getClientIp', () => ({getClientIp}));
+
+import {GET} from './route';
+
+function makeRequest(token?: string): Request {
+    const url = token
+        ? `https://m10z.de/api/diagnostics?token=${encodeURIComponent(token)}`
+        : 'https://m10z.de/api/diagnostics';
+    return new Request(url, {method: 'GET'});
+}
+
+beforeEach(() => {
+    vi.stubEnv('DIAGNOSTICS_TOKEN', 'test-token');
+    checkRateLimit.mockReturnValue({ok: true, retryAfterSeconds: 0});
+    verifySecret.mockReturnValue(false);
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('GET /api/diagnostics', () => {
+    test('returns 401 when no token is provided', async () => {
+        verifySecret.mockReturnValue(false);
+        const res = await GET(makeRequest());
+        expect(res.status).toBe(401);
+    });
+
+    test('returns 401 when wrong token is provided', async () => {
+        verifySecret.mockReturnValue(false);
+        const res = await GET(makeRequest('wrong-token'));
+        expect(res.status).toBe(401);
+    });
+
+    test('returns 429 with Retry-After header when rate limit is exceeded', async () => {
+        verifySecret.mockReturnValue(true);
+        checkRateLimit.mockReturnValue({ok: false, retryAfterSeconds: 5});
+
+        const res = await GET(makeRequest('test-token'));
+
+        expect(res.status).toBe(429);
+        expect(res.headers.get('Retry-After')).toBe('5');
+    });
+
+    test('returns 200 with diagnostic JSON when token is valid and within rate limit', async () => {
+        verifySecret.mockReturnValue(true);
+        checkRateLimit.mockReturnValue({ok: true, retryAfterSeconds: 0});
+        getRecentDiagnosticEvents.mockReturnValue([{type: 'test'}]);
+        getAudioFeedRuntimeState.mockReturnValue({running: true});
+        getSchedulerState.mockReturnValue({lastRun: 123});
+
+        const res = await GET(makeRequest('test-token'));
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body).toHaveProperty('now');
+        expect(body).toHaveProperty('events');
+        expect(body).toHaveProperty('memory');
+        expect(body).toHaveProperty('schedulers');
+        expect(typeof body.now).toBe('number');
+    });
+});

--- a/frontend/app/api/podcast-download/[slug]/route.test.ts
+++ b/frontend/app/api/podcast-download/[slug]/route.test.ts
@@ -1,0 +1,89 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+const {fetchPodcastBySlug, sendPodcastDownloadEvent, isAllowedDownloadTarget, shouldRecordDownloadForRange, mediaUrlToAbsolute, normalizeStrapiMedia, getStrapiApiBaseUrl, after} =
+    vi.hoisted(() => ({
+        fetchPodcastBySlug: vi.fn(),
+        sendPodcastDownloadEvent: vi.fn(),
+        isAllowedDownloadTarget: vi.fn(),
+        shouldRecordDownloadForRange: vi.fn().mockReturnValue(true),
+        mediaUrlToAbsolute: vi.fn().mockReturnValue('https://cdn.example.com/ep.mp3'),
+        normalizeStrapiMedia: vi.fn().mockReturnValue({}),
+        getStrapiApiBaseUrl: vi.fn().mockReturnValue(new URL('https://cms.example.com')),
+        after: vi.fn(),
+    }));
+
+vi.mock('next/server', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('next/server')>();
+    return {...actual, after};
+});
+
+vi.mock('@/src/lib/strapiContent', () => ({fetchPodcastBySlug}));
+vi.mock('@/src/lib/analytics/umamiServer', () => ({sendPodcastDownloadEvent}));
+vi.mock('@/src/lib/analytics/podcastDownload', () => ({
+    isAllowedDownloadTarget,
+    shouldRecordDownloadForRange,
+    buildPodcastDownloadPath: vi.fn(),
+    buildPodcastDownloadUrl: vi.fn(),
+    isPodcastDownloadTrackingEnabled: vi.fn(),
+}));
+vi.mock('@/src/lib/strapi/media', () => ({mediaUrlToAbsolute, normalizeStrapiMedia}));
+vi.mock('@/src/lib/strapi', () => ({getStrapiApiBaseUrl}));
+
+import {GET} from './route';
+
+function makeRequest(slug: string): [Request, {params: Promise<{slug: string}>}] {
+    const request = new Request(`https://m10z.de/api/podcast-download/${slug}`, {method: 'GET'});
+    const context = {params: Promise.resolve({slug})};
+    return [request, context];
+}
+
+beforeEach(() => {
+    fetchPodcastBySlug.mockReset();
+    isAllowedDownloadTarget.mockReset();
+    mediaUrlToAbsolute.mockReturnValue('https://cdn.example.com/ep.mp3');
+    normalizeStrapiMedia.mockReturnValue({});
+    getStrapiApiBaseUrl.mockReturnValue(new URL('https://cms.example.com'));
+    shouldRecordDownloadForRange.mockReturnValue(true);
+    after.mockClear();
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('GET /api/podcast-download/[slug]', () => {
+    test('returns 404 for an invalid slug pattern', async () => {
+        const [request, context] = makeRequest('../etc');
+        const res = await GET(request, context);
+        expect(res.status).toBe(404);
+        expect(fetchPodcastBySlug).not.toHaveBeenCalled();
+    });
+
+    test('returns 404 when Strapi returns null for the slug', async () => {
+        fetchPodcastBySlug.mockResolvedValue(null);
+        const [request, context] = makeRequest('valid-slug');
+        const res = await GET(request, context);
+        expect(res.status).toBe(404);
+    });
+
+    test('returns 404 when the resolved file URL is not on the allowlist', async () => {
+        fetchPodcastBySlug.mockResolvedValue({title: 'Episode 1', file: {}});
+        mediaUrlToAbsolute.mockReturnValue('https://cdn.example.com/ep.mp3');
+        isAllowedDownloadTarget.mockReturnValue(false);
+
+        const [request, context] = makeRequest('valid-slug');
+        const res = await GET(request, context);
+        expect(res.status).toBe(404);
+    });
+
+    test('returns 302 with Location and Cache-Control headers for a valid slug and allowed URL', async () => {
+        fetchPodcastBySlug.mockResolvedValue({title: 'Episode 1', file: {}});
+        mediaUrlToAbsolute.mockReturnValue('https://cdn.example.com/ep.mp3');
+        isAllowedDownloadTarget.mockReturnValue(true);
+
+        const [request, context] = makeRequest('valid-slug');
+        const res = await GET(request, context);
+
+        expect(res.status).toBe(302);
+        expect(res.headers.get('Location')).toBe('https://cdn.example.com/ep.mp3');
+        expect(res.headers.get('Cache-Control')).toBe('no-store');
+    });
+});

--- a/frontend/app/preview/artikel/[slug]/page.tsx
+++ b/frontend/app/preview/artikel/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import {type Metadata} from 'next';
 import {notFound} from 'next/navigation';
+import {headers} from 'next/headers';
 
 import {fetchArticleBySlugForPreview} from '@/src/lib/strapiContent';
 import {validateSlugSafe} from '@/src/lib/security/slugValidation';
 import {verifySecret} from '@/src/lib/security/verifySecret';
+import {checkRateLimit} from '@/src/lib/security/rateLimit';
 import {ArticleDetail} from '@/src/components/ArticleDetail';
 import PreviewBanner from '@/src/components/PreviewBanner';
 import {getErrorMessage, isTimeoutOrSocketError} from '@/src/lib/errors';
@@ -28,6 +30,10 @@ export default async function ArticlePreviewPage({params, searchParams}: PagePro
     const {slug: rawSlug} = await params;
     const slug = validateSlugSafe(rawSlug);
     if (!slug) notFound();
+
+    const ip = (await headers()).get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+    const rl = checkRateLimit(`preview:${ip}`, {windowMs: 60_000, max: 20});
+    if (!rl.ok) notFound();
 
     const {secret, status} = await searchParams;
     const expected = process.env.STRAPI_PREVIEW_SECRET ?? null;

--- a/frontend/app/preview/podcasts/[slug]/page.tsx
+++ b/frontend/app/preview/podcasts/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import {type Metadata} from 'next';
 import {notFound} from 'next/navigation';
+import {headers} from 'next/headers';
 
 import {fetchPodcastBySlugForPreview} from '@/src/lib/strapiContent';
 import {validateSlugSafe} from '@/src/lib/security/slugValidation';
 import {verifySecret} from '@/src/lib/security/verifySecret';
+import {checkRateLimit} from '@/src/lib/security/rateLimit';
 import {PodcastDetail} from '@/src/components/PodcastDetail';
 import PreviewBanner from '@/src/components/PreviewBanner';
 import {getErrorMessage, isTimeoutOrSocketError} from '@/src/lib/errors';
@@ -28,6 +30,10 @@ export default async function PodcastPreviewPage({params, searchParams}: PagePro
     const {slug: rawSlug} = await params;
     const slug = validateSlugSafe(rawSlug);
     if (!slug) notFound();
+
+    const ip = (await headers()).get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+    const rl = checkRateLimit(`preview:${ip}`, {windowMs: 60_000, max: 20});
+    if (!rl.ok) notFound();
 
     const {secret, status} = await searchParams;
     const expected = process.env.STRAPI_PREVIEW_SECRET ?? null;

--- a/frontend/src/lib/rss/feedCache.ts
+++ b/frontend/src/lib/rss/feedCache.ts
@@ -204,13 +204,35 @@ export function createFeedCache(spec: FeedSpec, deps: FeedCacheDeps = {}): FeedC
             try {
                 const disk = await readFeedFromDisk();
                 if (disk) cachedFeed = disk;
-            } catch {
-                // ignore
+            } catch (err) {
+                console.warn('[feedCache] warmup: failed to read feed from disk', err);
+                recordDiagnosticEvent({
+                    ts: Date.now(),
+                    kind: 'route',
+                    name: `feed.${spec.feedKey}.warmup`,
+                    ok: false,
+                    durationMs: 0,
+                    detail:
+                        err instanceof Error
+                            ? {errorName: err.name, errorMessage: err.message}
+                            : {errorName: 'UnknownError'},
+                });
             }
             try {
                 await refresh();
-            } catch {
-                // ignore
+            } catch (err) {
+                console.warn('[feedCache] warmup: initial feed refresh failed', err);
+                recordDiagnosticEvent({
+                    ts: Date.now(),
+                    kind: 'route',
+                    name: `feed.${spec.feedKey}.warmup`,
+                    ok: false,
+                    durationMs: 0,
+                    detail:
+                        err instanceof Error
+                            ? {errorName: err.name, errorMessage: err.message}
+                            : {errorName: 'UnknownError'},
+                });
             }
         })();
     }

--- a/frontend/src/lib/rss/markdownToHtml.test.ts
+++ b/frontend/src/lib/rss/markdownToHtml.test.ts
@@ -42,6 +42,20 @@ describe('markdownToHtml — sanitization (XSS)', () => {
     });
 });
 
+describe('markdownToHtml — rel=noopener injection', () => {
+    test('adds rel="noopener noreferrer" to <a target="_blank"> links', () => {
+        const html = markdownToHtml('<a href="https://example.com" target="_blank">link</a>');
+        expect(html).toContain('rel="noopener noreferrer"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('href="https://example.com"');
+    });
+
+    test('does not add rel to links without target="_blank"', () => {
+        const html = markdownToHtml('[M10Z](https://m10z.de)');
+        expect(html).not.toContain('noopener');
+    });
+});
+
 describe('getMarkdownToHtmlState', () => {
     test('reports a non-empty allow-list and increments conversion telemetry', () => {
         const before = getMarkdownToHtmlState().conversions;

--- a/frontend/src/lib/rss/markdownToHtml.ts
+++ b/frontend/src/lib/rss/markdownToHtml.ts
@@ -81,6 +81,14 @@ export function markdownToHtml(markdownText: string): string {
     const DOMPurify = createDOMPurify(window as any);
     domPurifyInstancesCreated += 1;
 
+    // Ensure every <a target="_blank"> gets rel="noopener noreferrer" to
+    // prevent reverse tabnapping attacks in RSS reader UAs that honour the attribute.
+    DOMPurify.addHook('afterSanitizeAttributes', (node: Element) => {
+        if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+            node.setAttribute('rel', 'noopener noreferrer');
+        }
+    });
+
     try {
         // Marked output can include HTML; we sanitize after conversion.
         const rawHtml = marked.parse(markdownText, {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     },
     test: {
         environment: 'node',
-        include: ['src/**/*.test.ts'],
+        include: ['src/**/*.test.ts', 'app/**/*.test.ts'],
         globals: false,
     },
 });


### PR DESCRIPTION
## Summary

Six improvements from the `/improve` audit (plans 001–006, issues #574–#579):

- **fix(frontend):** Log warmup errors in feed cache — replaces two silent `// ignore` catch blocks in `feedCache.ts:ensureWarmup()` with `recordDiagnosticEvent` + `console.warn` calls (#574)
- **fix(frontend):** Rate-limit preview secret validation — adds `checkRateLimit` before `verifySecret` in both preview pages, consistent with every other authenticated endpoint (#575)
- **fix(frontend):** Add `rel="noopener noreferrer"` to external links in RSS feed HTML — DOMPurify hook on per-call instance; brings RSS renderer to parity with `Anchor.tsx` (#576)
- **test(frontend):** API route handler tests — 4 new test files (invalidation adapter, diagnostics, podcast-download, articlefeed smoke); vitest config updated to discover `app/**`; 545 tests total (#577)
- **fix(backend):** Declare `strapi` global explicitly in lifecycle handlers — `declare const strapi: StrapiGlobal | undefined` + null-safe handler + 6-case unit test (#578)
- **refactor(backend):** Enable TypeScript strict mode — flips `strict: false` → `strict: true` in `backend/tsconfig.json`, fixes all 17 resulting errors across config files, `src/index.ts`, `wordCount.ts` (#579)

## Test plan

- [ ] `cd frontend && vitest run` → 53 files, 545 tests, all pass
- [ ] `cd backend && vitest run` → 9 files, 70 tests, all pass
- [ ] `cd backend && tsc --noEmit` → 0 errors

Closes #574, #575, #576, #577, #578, #579

🤖 Generated with [Claude Code](https://claude.ai/claude-code)