### PR TITLE
fix: semantic HTML audit issues

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -54,7 +54,7 @@ export default function Footer() {
             <div className={styles.content}>
                 {sections.map((section) => (
                     <div key={section.title} className={styles.section}>
-                        <span className={styles.sectionTitle}>{section.title}</span>
+                        <h2 className={styles.sectionTitle}>{section.title}</h2>
                         <ul className={styles.linkList}>
                             {section.links.map((link) => (
                                 <li key={link.href}>
@@ -67,6 +67,7 @@ export default function Footer() {
                                             data-umami-event={umamiEventId(['footer', section.title, link.label])}
                                         >
                                             {link.label}
+                                            <span className="visually-hidden"> (öffnet in neuem Fenster)</span>
                                         </a>
                                     ) : (
                                         <Link className={styles.link} href={link.href}>

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -68,9 +68,9 @@ export async function HomePage({page}: {page: number}) {
             <div className={styles.page}>
                 <Card variant="empty">
                     <p>Fehler beim Laden der Inhalte.</p>
-                    <a href="/" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
+                    <Link href="/" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
                         Erneut versuchen
-                    </a>
+                    </Link>
                 </Card>
             </div>
         );
@@ -93,7 +93,7 @@ export async function HomePage({page}: {page: number}) {
     return (
         <div className={styles.page}>
             <h1 className="visually-hidden">Mindestens 10 Zeichen</h1>
-            <aside className={styles.toc} aria-label="Inhaltsverzeichnis">
+            <nav className={styles.toc} aria-label="Inhaltsverzeichnis">
                 <h2 className={styles.tocTitle}>Inhaltsverzeichnis</h2>
                 {currentItems.length === 0 ? (
                     <p className={styles.empty}>Gerade nichts Neues.</p>
@@ -132,7 +132,7 @@ export async function HomePage({page}: {page: number}) {
                         })}
                     </ul>
                 )}
-            </aside>
+            </nav>
 
             <section className={styles.feed} aria-label="Neueste Inhalte">
                 {currentItems.length === 0 ? (

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -29,7 +29,7 @@ export function Pagination({
             <div className={styles.pageInfo}>Seite {currentPage}</div>
             <div className={styles.pageControls}>
                 {isFirstPage ? (
-                    <span className={`${styles.pageButton} ${styles.pageButtonDisabled}`} aria-disabled>
+                    <span className={`${styles.pageButton} ${styles.pageButtonDisabled}`} aria-disabled="true">
                         Zurück
                     </span>
                 ) : previousHref ? (
@@ -46,7 +46,7 @@ export function Pagination({
                     </button>
                 )}
                 {isLastPage ? (
-                    <span className={`${styles.pageButton} ${styles.pageButtonDisabled}`} aria-disabled>
+                    <span className={`${styles.pageButton} ${styles.pageButtonDisabled}`} aria-disabled="true">
                         Weiter
                     </span>
                 ) : nextHref ? (


### PR DESCRIPTION
## Summary

Fixes 5 semantic HTML issues found via MDN Web Docs audit of the homepage.

### Changes

| File | Change | Severity |
|------|--------|----------|
| `Footer.tsx` | Section titles `<span>` → `<h2>` | ❌ |
| `Footer.tsx` | External links get visually-hidden "öffnet in neuem Fenster" | ❌ |
| `HomePage.tsx` | TOC `<aside>` → `<nav>` | ❌ |
| `HomePage.tsx` | Error retry link `<a>` → Next `<Link>` | ⚠️ |
| `Pagination.tsx` | `aria-disabled` → `aria-disabled="true"` | ⚠️ |

### Verification

- ✅ `pnpm run test:run` — 591 tests pass
- ✅ `npx tsc --noEmit` — zero errors
- ✅ `pnpm run build` — production build succeeds