### PR TITLE
fix: semantic HTML audit v2 — cross-page fixes

### DIFF
--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -16,6 +16,7 @@ export default function ChangelogPage() {
     const markdown = readFileSync(path.join(process.cwd(), 'public', 'changelog.md'), 'utf-8');
     return (
         <div data-list-page>
+            <h1>Changelog</h1>
             <Markdown markdown={markdown} />
         </div>
     );

--- a/frontend/app/kategorien/page.tsx
+++ b/frontend/app/kategorien/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import {type Metadata} from 'next';
 
 import {fetchCategoriesWithContent} from '@/src/lib/strapiContent';
@@ -24,9 +25,9 @@ export default async function CategoriesPage() {
                 <h1>Kategorien</h1>
                 <Card variant="empty">
                     <p>Fehler beim Laden der Kategorien.</p>
-                    <a href="/kategorien" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
+                    <Link href="/kategorien" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
                         Erneut versuchen
-                    </a>
+                    </Link>
                 </Card>
             </section>
         );

--- a/frontend/app/team/page.tsx
+++ b/frontend/app/team/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import {type Metadata} from 'next';
 import {fetchAuthorsList} from '@/src/lib/strapiContent';
 import {buildStaticListMetadata} from '@/src/lib/metadata/staticListMetadata';
@@ -27,9 +28,9 @@ export default async function TeamPage() {
                 <h1>Team</h1>
                 <Card variant="empty">
                     <p>Fehler beim Laden der Autoren.</p>
-                    <a href="/team" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
+                    <Link href="/team" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
                         Erneut versuchen
-                    </a>
+                    </Link>
                 </Card>
             </section>
         );

--- a/frontend/src/components/ArticleListPage.tsx
+++ b/frontend/src/components/ArticleListPage.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import {fetchArticlesPage} from '@/src/lib/strapiContent';
 import {ContentGrid} from '@/src/components/ContentGrid';
 import {ArticleCard} from '@/src/components/ArticleCard';
@@ -42,9 +43,9 @@ export async function ArticleListPage({
                 <h1>Artikel</h1>
                 <Card variant="empty">
                     <p>Fehler beim Laden der Artikel.</p>
-                    <a href="/artikel" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
+                    <Link href="/artikel" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
                         Erneut versuchen
-                    </a>
+                    </Link>
                 </Card>
             </section>
         );

--- a/frontend/src/components/AuthorContentPage.module.css
+++ b/frontend/src/components/AuthorContentPage.module.css
@@ -1,3 +1,9 @@
+.sectionTitle {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 16px;
+}
+
 .filterRow {
     display: flex;
     gap: 10px;

--- a/frontend/src/components/AuthorContentPage.tsx
+++ b/frontend/src/components/AuthorContentPage.tsx
@@ -132,7 +132,8 @@ export async function AuthorContentPage<TItem extends {slug: string}>(props: Aut
             <AuthorHeader author={author} />
             <AuthorNav authorSlug={slug} activeSection={props.activeSection} />
 
-            <section title={props.sectionLabel}>
+            <section>
+                <h2 className={styles.sectionTitle}>{props.sectionLabel}</h2>
                 {categorySlug ? (
                     <div className={styles.filterRow}>
                         <Link

--- a/frontend/src/components/M12GGameDetail.tsx
+++ b/frontend/src/components/M12GGameDetail.tsx
@@ -20,21 +20,21 @@ export function M12GGameDetail({game}: M12GGameDetailProps) {
                 <h1 className={styles.title}>{game.name}</h1>
                 <div className={styles.subline}>
                     <a href={game.link} target="_blank" rel="noreferrer noopener">
-                        Store-Seite öffnen ↗
+                        Store-Seite öffnen ↗<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
                     </a>
                 </div>
             </header>
 
-            <div className={styles.stats}>
+            <dl className={styles.stats}>
                 <div className={styles.stat}>
-                    <span className={styles.statLabel}>Siege</span>
-                    <span className={styles.statValue}>{game.wins}</span>
+                    <dt className={styles.statLabel}>Siege</dt>
+                    <dd className={styles.statValue}>{game.wins}</dd>
                 </div>
                 <div className={styles.stat}>
-                    <span className={styles.statLabel}>Stimmen gesamt</span>
-                    <span className={styles.statValue}>{game.totalVotes}</span>
+                    <dt className={styles.statLabel}>Stimmen gesamt</dt>
+                    <dd className={styles.statValue}>{game.totalVotes}</dd>
                 </div>
-            </div>
+            </dl>
 
             <section className={styles.timelineWrapper}>
                 <h2 className={styles.timelineHeading}>Auftritte</h2>
@@ -48,7 +48,7 @@ export function M12GGameDetail({game}: M12GGameDetailProps) {
                                 ) : null}
                                 {entry.forumThreadUrl ? (
                                     <a href={entry.forumThreadUrl} target="_blank" rel="noreferrer noopener">
-                                        {formatMonthLong(entry.month)}
+                                        {formatMonthLong(entry.month)}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
                                     </a>
                                 ) : (
                                     formatMonthLong(entry.month)

--- a/frontend/src/components/M12GGameDetail.tsx
+++ b/frontend/src/components/M12GGameDetail.tsx
@@ -20,7 +20,7 @@ export function M12GGameDetail({game}: M12GGameDetailProps) {
                 <h1 className={styles.title}>{game.name}</h1>
                 <div className={styles.subline}>
                     <a href={game.link} target="_blank" rel="noreferrer noopener">
-                        Store-Seite öffnen ↗<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
+                        Store-Seite öffnen ↗<span className='visually-hidden'> (öffnet in neuem Fenster)</span>
                     </a>
                 </div>
             </header>
@@ -48,7 +48,7 @@ export function M12GGameDetail({game}: M12GGameDetailProps) {
                                 ) : null}
                                 {entry.forumThreadUrl ? (
                                     <a href={entry.forumThreadUrl} target="_blank" rel="noreferrer noopener">
-                                        {formatMonthLong(entry.month)}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
+                                        {formatMonthLong(entry.month)}<span className='visually-hidden'> (öffnet in neuem Fenster)</span>
                                     </a>
                                 ) : (
                                     formatMonthLong(entry.month)

--- a/frontend/src/components/M12GGameIndex.tsx
+++ b/frontend/src/components/M12GGameIndex.tsx
@@ -87,7 +87,7 @@ export function M12GGameIndex({games}: M12GGameIndexProps) {
                                         href={game.link}
                                         target="_blank"
                                         rel="noreferrer noopener"
-                                        aria-label={`${game.name} im Store öffnen`}>
+                                        aria-label={`${game.name} im Store öffnen (öffnet in neuem Fenster)`}>
                                         ↗
                                     </a>
                                     {game.wins > 0 ? (

--- a/frontend/src/components/M12GLeaderboard.tsx
+++ b/frontend/src/components/M12GLeaderboard.tsx
@@ -44,7 +44,7 @@ export function M12GLeaderboard({entries}: M12GLeaderboardProps) {
                                     href={entry.link}
                                     target="_blank"
                                     rel="noreferrer noopener"
-                                    aria-label={`${entry.name} im Store öffnen`}
+                                    aria-label={`${entry.name} im Store öffnen (öffnet in neuem Fenster)`}
                                 >
                                     ↗
                                 </a>

--- a/frontend/src/components/M12GMonthCard.tsx
+++ b/frontend/src/components/M12GMonthCard.tsx
@@ -40,7 +40,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                                                 target="_blank"
                                                 rel="noreferrer noopener"
                                             >
-                                                {game.name}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
+                                                {game.name}<span className='visually-hidden'> (öffnet in neuem Fenster)</span>
                                             </a>
                                             {game.earlyAccess ? (
                                                 <span className={styles.earlyAccess} title="Early Access">EA</span>
@@ -67,7 +67,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                                         target="_blank"
                                         rel="noreferrer noopener"
                                     >
-                                        {game.name}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
+                                        {game.name}<span className='visually-hidden'> (öffnet in neuem Fenster)</span>
                                     </a>
                                     {game.earlyAccess ? (
                                         <span className={styles.earlyAccess} title="Early Access">EA</span>
@@ -92,7 +92,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                         rel="noreferrer noopener"
                     >
                         <ChatsCircleIcon size={18} weight="regular" />
-                        Forum-Thread<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
+                        Forum-Thread<span className='visually-hidden'> (öffnet in neuem Fenster)</span>
                     </a>
                 </footer>
             ) : null}

--- a/frontend/src/components/M12GMonthCard.tsx
+++ b/frontend/src/components/M12GMonthCard.tsx
@@ -40,7 +40,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                                                 target="_blank"
                                                 rel="noreferrer noopener"
                                             >
-                                                {game.name}
+                                                {game.name}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
                                             </a>
                                             {game.earlyAccess ? (
                                                 <span className={styles.earlyAccess} title="Early Access">EA</span>
@@ -67,7 +67,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                                         target="_blank"
                                         rel="noreferrer noopener"
                                     >
-                                        {game.name}
+                                        {game.name}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
                                     </a>
                                     {game.earlyAccess ? (
                                         <span className={styles.earlyAccess} title="Early Access">EA</span>
@@ -92,7 +92,7 @@ export function M12GMonthCard({month}: M12GMonthCardProps) {
                         rel="noreferrer noopener"
                     >
                         <ChatsCircleIcon size={18} weight="regular" />
-                        Forum-Thread
+                        Forum-Thread<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
                     </a>
                 </footer>
             ) : null}

--- a/frontend/src/components/M12GWinnerTimeline.tsx
+++ b/frontend/src/components/M12GWinnerTimeline.tsx
@@ -25,7 +25,7 @@ export function M12GWinnerTimeline({winners}: M12GWinnerTimelineProps) {
                             target="_blank"
                             rel="noreferrer noopener"
                         >
-                            {entry.gameName}
+                            {entry.gameName}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
                         </a>
                         <span className={styles.votes}>{formatVotes(entry.votes)}</span>
                     </li>

--- a/frontend/src/components/M12GWinnerTimeline.tsx
+++ b/frontend/src/components/M12GWinnerTimeline.tsx
@@ -25,7 +25,7 @@ export function M12GWinnerTimeline({winners}: M12GWinnerTimelineProps) {
                             target="_blank"
                             rel="noreferrer noopener"
                         >
-                            {entry.gameName}<span className="visually-hidden"> (öffnet in neuem Fenster)</span>
+                            {entry.gameName}<span className='visually-hidden'> (öffnet in neuem Fenster)</span>
                         </a>
                         <span className={styles.votes}>{formatVotes(entry.votes)}</span>
                     </li>

--- a/frontend/src/components/PodcastListPage.tsx
+++ b/frontend/src/components/PodcastListPage.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import {fetchPodcastsPage} from '@/src/lib/strapiContent';
 import {ContentGrid} from '@/src/components/ContentGrid';
 import {PodcastCard} from '@/src/components/PodcastCard';
@@ -44,9 +45,9 @@ export async function PodcastListPage({
                 <h1>Podcasts</h1>
                 <Card variant="empty">
                     <p>Fehler beim Laden der Podcasts.</p>
-                    <a href="/podcasts" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
+                    <Link href="/podcasts" style={{marginTop: '1rem', padding: '0.5rem 1rem', display: 'inline-block'}}>
                         Erneut versuchen
-                    </a>
+                    </Link>
                 </Card>
             </section>
         );

--- a/frontend/src/components/PreviewBanner.tsx
+++ b/frontend/src/components/PreviewBanner.tsx
@@ -11,8 +11,8 @@ export default function PreviewBanner({status = 'draft'}: PreviewBannerProps) {
             : 'Preview Mode - This content is not published.';
 
     return (
-        <output className={styles.banner}>
+        <div className={styles.banner} role="status">
             {message}
-        </output>
+        </div>
     );
 }


### PR DESCRIPTION
## Summary

Second round of semantic HTML fixes based on MDN Web Docs audit, addressing issues across all pages.

### Changes

| File | Change | Severity |
|------|--------|----------|
| `AuthorContentPage.tsx` | `<section title="…">` → `<section>` + `<h2>` | ❌ |
| `changelog/page.tsx` | Added missing `<h1>Changelog</h1>` | ❌ |
| `ArticleListPage.tsx` | Retry link `<a>` → `<Link>` | ❌ |
| `PodcastListPage.tsx` | Retry link `<a>` → `<Link>` | ❌ |
| `kategorien/page.tsx` | Retry link `<a>` → `<Link>` | ❌ |
| `team/page.tsx` | Retry link `<a>` → `<Link>` | ❌ |
| `M12GGameDetail.tsx` | + visually-hidden new-window indicator; `<div>`/ `<span>` → `<dl>`/`<dt>`/`<dd>` | ❌ / ⚠️ |
| `M12GMonthCard.tsx` | + visually-hidden new-window indicator | ❌ |
| `M12GGameIndex.tsx` | + aria-label new-window indicator | ❌ |
| `M12GLeaderboard.tsx` | + aria-label new-window indicator | ❌ |
| `M12GWinnerTimeline.tsx` | + visually-hidden new-window indicator | ❌ |
| `PreviewBanner.tsx` | `<output>` → `<div role="status">` | ⚠️ |

### Verification

- ✅ `pnpm run test:run` — 591 tests pass
- ✅ `npx tsc --noEmit` — zero errors
- ✅ `pnpm run build` — production build succeeds