### PR TITLE
feat: add desktop/browser push notifications for new articles and podcasts

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,3 +36,9 @@ EMAIL_REPLY_TO=no-reply@pnn-it.de
 
 # Shared secret for preview URLs (must match frontend STRAPI_PREVIEW_SECRET)
 STRAPI_PREVIEW_SECRET=
+
+# Web Push Notifications (VAPID)
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:nerlich@pn-it.de
+PUSH_NOTIFICATION_SECRET=

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
         "react-router-dom": "^6.30.4",
         "sharp": "^0.33.5",
         "strapi-plugin-config-sync": "^3.2.0",
+        "web-push": "^3.6.7",
         "styled-components": "~6.1.19"
     },
     "devDependencies": {

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       styled-components:
         specifier: ~6.1.19
         version: 6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
     devDependencies:
       '@types/node':
         specifier: ^22.20.1
@@ -2917,6 +2920,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
@@ -3038,6 +3045,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -3103,6 +3113,9 @@ packages:
 
   blurhash@2.0.5:
     resolution: {integrity: sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==}
+
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -4296,9 +4309,17 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -5123,6 +5144,9 @@ packages:
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -6944,6 +6968,11 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -8217,7 +8246,7 @@ snapshots:
 
   '@koa/router@12.0.2':
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.0
       koa-compose: 4.1.0
       methods: 1.1.2
@@ -10735,6 +10764,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   aggregate-error@3.1.0:
     dependencies:
       clean-stack: 2.2.0
@@ -10849,6 +10880,13 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.5
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
@@ -10904,6 +10942,8 @@ snapshots:
       readable-stream: 3.6.2
 
   blurhash@2.0.5: {}
+
+  bn.js@4.12.5: {}
 
   body-parser@2.3.0:
     dependencies:
@@ -12194,9 +12234,18 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -13140,6 +13189,8 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.3
       webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.22)
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -14994,6 +15045,16 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 

--- a/backend/src/api/push-subscription/content-types/push-subscription/schema.json
+++ b/backend/src/api/push-subscription/content-types/push-subscription/schema.json
@@ -1,0 +1,24 @@
+{
+    "kind": "collectionType",
+    "collectionName": "push_subscriptions",
+    "info": {
+        "singularName": "push-subscription",
+        "pluralName": "push-subscriptions",
+        "displayName": "Push Subscription"
+    },
+    "options": {
+        "draftAndPublish": false
+    },
+    "pluginOptions": {},
+    "attributes": {
+        "endpoint": {
+            "type": "string",
+            "required": true,
+            "unique": true
+        },
+        "keys": {
+            "type": "json",
+            "required": true
+        }
+    }
+}

--- a/backend/src/api/push-subscription/controllers/push-subscription.ts
+++ b/backend/src/api/push-subscription/controllers/push-subscription.ts
@@ -1,0 +1,74 @@
+/**
+ * push-subscription controller
+ */
+
+import {factories} from '@strapi/strapi';
+
+const PUSH_SECRET_HEADER = 'x-m10z-push-secret';
+
+function verifyPushSecret(request: any): boolean {
+    const provided = request.request?.header?.(PUSH_SECRET_HEADER)
+        ?? request.headers?.[PUSH_SECRET_HEADER]
+        ?? null;
+    const expected = process.env.PUSH_NOTIFICATION_SECRET ?? null;
+    if (!provided || !expected) return false;
+    try {
+        const {timingSafeEqual} = require('crypto');
+        const bufProvided = Buffer.from(provided);
+        const bufExpected = Buffer.from(expected);
+        if (bufProvided.length !== bufExpected.length) return false;
+        return timingSafeEqual(bufProvided, bufExpected);
+    } catch {
+        return provided === expected;
+    }
+}
+
+export default factories.createCoreController('api::push-subscription.push-subscription', () => ({
+    async subscribe(ctx: any) {
+        if (!verifyPushSecret(ctx)) {
+            return ctx.unauthorized('Invalid push secret');
+        }
+
+        const {endpoint, keys} = ctx.request.body;
+        if (!endpoint || !keys?.p256dh || !keys?.auth) {
+            return ctx.badRequest('Invalid subscription object');
+        }
+
+        const existing = await strapi.db.query('api::push-subscription.push-subscription').findOne({
+            where: {endpoint},
+        });
+
+        if (existing) {
+            return ctx.send({status: 'exists'}, 200);
+        }
+
+        await strapi.db.query('api::push-subscription.push-subscription').create({
+            data: {endpoint, keys},
+        });
+
+        return ctx.send({status: 'created'}, 201);
+    },
+
+    async unsubscribe(ctx: any) {
+        if (!verifyPushSecret(ctx)) {
+            return ctx.unauthorized('Invalid push secret');
+        }
+
+        const {endpoint} = ctx.request.body;
+        if (!endpoint) {
+            return ctx.badRequest('Missing endpoint');
+        }
+
+        const existing = await strapi.db.query('api::push-subscription.push-subscription').findOne({
+            where: {endpoint},
+        });
+
+        if (existing) {
+            await strapi.db.query('api::push-subscription.push-subscription').delete({
+                where: {endpoint},
+            });
+        }
+
+        return ctx.send({status: 'deleted'}, 204);
+    },
+}));

--- a/backend/src/api/push-subscription/routes/push-subscription-custom.ts
+++ b/backend/src/api/push-subscription/routes/push-subscription-custom.ts
@@ -1,0 +1,22 @@
+export default {
+    routes: [
+        {
+            method: 'POST',
+            path: '/push-subscriptions',
+            handler: 'push-subscription.subscribe',
+            config: {
+                auth: false,
+                policies: [],
+            },
+        },
+        {
+            method: 'DELETE',
+            path: '/push-subscriptions',
+            handler: 'push-subscription.unsubscribe',
+            config: {
+                auth: false,
+                policies: [],
+            },
+        },
+    ],
+};

--- a/backend/src/api/push-subscription/routes/push-subscription.ts
+++ b/backend/src/api/push-subscription/routes/push-subscription.ts
@@ -1,0 +1,7 @@
+/**
+ * push-subscription router
+ */
+
+import {factories} from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::push-subscription.push-subscription');

--- a/backend/src/api/push-subscription/services/push-subscription.ts
+++ b/backend/src/api/push-subscription/services/push-subscription.ts
@@ -1,0 +1,7 @@
+/**
+ * push-subscription service
+ */
+
+import {factories} from '@strapi/strapi';
+
+export default factories.createCoreService('api::push-subscription.push-subscription');

--- a/backend/src/middlewares/cacheInvalidation.ts
+++ b/backend/src/middlewares/cacheInvalidation.ts
@@ -8,6 +8,7 @@
 import {DOCUMENT_INVALIDATION} from '../shared/contracts/invalidation/manifest';
 
 import {queueCacheInvalidation} from '../services/asyncCacheInvalidationQueue';
+import {sendPushNotifications} from '../services/pushNotificationService';
 
 export async function cacheInvalidationMiddleware(
     context: {uid: string; action: string; params?: any},
@@ -31,6 +32,30 @@ export async function cacheInvalidationMiddleware(
 
     for (const target of entry.targets) {
         queueCacheInvalidation(target, strapiInstance);
+    }
+
+    // Fire push notifications for article/podcast publish actions
+    if (context.action === 'publish') {
+        const contentType = context.uid === 'api::article.article' ? 'article'
+            : context.uid === 'api::podcast.podcast' ? 'podcast'
+            : null;
+
+        if (contentType) {
+            const document = context.params?.data ?? context.params?.document ?? {};
+            const articleTitle: string | undefined = document.title;
+            const articleSlug: string | undefined = document.slug;
+
+            if (articleTitle && articleSlug) {
+                const url = contentType === 'article'
+                    ? `https://m10z.de/artikel/${articleSlug}`
+                    : `https://m10z.de/podcasts/${articleSlug}`;
+
+                // Fire-and-forget: don't block the publish response
+                sendPushNotifications(contentType, articleTitle, url, strapiInstance).catch(
+                    (error) => strapiInstance.log.warn('[pushNotifications] Error sending push notification', error)
+                );
+            }
+        }
     }
 
     return result;

--- a/backend/src/services/pushNotificationService.ts
+++ b/backend/src/services/pushNotificationService.ts
@@ -1,0 +1,98 @@
+import webpush from 'web-push';
+
+type StrapiLike = {
+    log: {
+        info: (message: string) => void;
+        warn: (message: string, error?: unknown) => void;
+    };
+    db: {
+        query(uid: string): {
+            findMany(): Promise<{id: number; endpoint: string; keys: {p256dh: string; auth: string}}[]>;
+            delete(opts: {where: {endpoint: string}}): Promise<void>;
+        };
+    };
+};
+
+function getVapidConfig(): {subject: string; publicKey: string; privateKey: string} | null {
+    const subject = process.env.VAPID_SUBJECT;
+    const publicKey = process.env.VAPID_PUBLIC_KEY;
+    const privateKey = process.env.VAPID_PRIVATE_KEY;
+    if (!subject || !publicKey || !privateKey) {
+        return null;
+    }
+    return {subject, publicKey, privateKey};
+}
+
+export async function sendPushNotifications(
+    contentType: 'article' | 'podcast',
+    title: string,
+    url: string,
+    strapi: StrapiLike | null,
+): Promise<void> {
+    const vapid = getVapidConfig();
+    if (!vapid) {
+        strapi?.log.warn('[pushNotifications] VAPID not configured, skipping push dispatch');
+        return;
+    }
+
+    webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
+
+    let subscriptions: {id: number; endpoint: string; keys: {p256dh: string; auth: string}}[] = [];
+    try {
+        const result = await strapi?.db?.query('api::push-subscription.push-subscription').findMany();
+        if (!result || result.length === 0) {
+            strapi?.log.info('[pushNotifications] No subscriptions to notify');
+            return;
+        }
+        subscriptions = Array.isArray(result) ? result : [];
+    } catch (error) {
+        strapi?.log.warn('[pushNotifications] Failed to fetch subscriptions', error);
+        return;
+    }
+
+    const payload = JSON.stringify({
+        title: `Neuer ${contentType === 'article' ? 'Artikel' : 'Podcast'}: ${title}`,
+        body: `Schau dir den neuen ${contentType === 'article' ? 'Artikel' : 'Podcast'} auf m10z.de an!`,
+        url,
+        icon: '/icon-192.png',
+    });
+
+    let successCount = 0;
+    let failureCount = 0;
+    const staleEndpoints: string[] = [];
+
+    for (const sub of subscriptions) {
+        try {
+            await webpush.sendNotification(
+                {
+                    endpoint: sub.endpoint,
+                    keys: sub.keys,
+                },
+                payload,
+            );
+            successCount++;
+        } catch (error: any) {
+            failureCount++;
+            if (error?.statusCode === 410 || error?.statusCode === 404) {
+                staleEndpoints.push(sub.endpoint);
+            }
+        }
+    }
+
+    if (staleEndpoints.length > 0) {
+        try {
+            for (const endpoint of staleEndpoints) {
+                await strapi?.db?.query('api::push-subscription.push-subscription').delete({
+                    where: {endpoint},
+                });
+            }
+            strapi?.log.info(`[pushNotifications] Removed ${staleEndpoints.length} stale subscription(s)`);
+        } catch (error) {
+            strapi?.log.warn('[pushNotifications] Failed to remove stale subscriptions', error);
+        }
+    }
+
+    strapi?.log.info(
+        `[pushNotifications] Sent ${successCount} notification(s) for "${title}" (${failureCount} failure(s))`,
+    );
+}

--- a/backend/src/types/web-push.d.ts
+++ b/backend/src/types/web-push.d.ts
@@ -1,0 +1,32 @@
+declare module 'web-push' {
+    interface PushSubscription {
+        endpoint: string;
+        keys: {
+            p256dh: string;
+            auth: string;
+        };
+    }
+
+    interface VapidDetails {
+        subject: string;
+        publicKey: string;
+        privateKey: string;
+    }
+
+    export function setVapidDetails(
+        subject: string,
+        publicKey: string,
+        privateKey: string,
+    ): void;
+
+    export function sendNotification(
+        subscription: PushSubscription,
+        payload: string,
+        options?: Record<string, unknown>,
+    ): Promise<void>;
+
+    export function generateVAPIDKeys(): {
+        publicKey: string;
+        privateKey: string;
+    };
+}

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -863,6 +863,38 @@ export interface ApiSearchIndexSearchIndex extends Struct.SingleTypeSchema {
     };
 }
 
+export interface ApiPushSubscriptionPushSubscription
+    extends Struct.CollectionTypeSchema {
+    collectionName: 'push_subscriptions';
+    info: {
+        displayName: 'Push Subscription';
+        pluralName: 'push-subscriptions';
+        singularName: 'push-subscription';
+    };
+    options: {
+        draftAndPublish: false;
+    };
+    attributes: {
+        createdAt: Schema.Attribute.DateTime;
+        createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+            Schema.Attribute.Private;
+        endpoint: Schema.Attribute.String &
+            Schema.Attribute.Required &
+            Schema.Attribute.Unique;
+        keys: Schema.Attribute.JSON & Schema.Attribute.Required;
+        locale: Schema.Attribute.String & Schema.Attribute.Private;
+        localizations: Schema.Attribute.Relation<
+            'oneToMany',
+            'api::push-subscription.push-subscription'
+        > &
+            Schema.Attribute.Private;
+        publishedAt: Schema.Attribute.DateTime;
+        updatedAt: Schema.Attribute.DateTime;
+        updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+            Schema.Attribute.Private;
+    };
+}
+
 export interface PluginContentReleasesRelease
     extends Struct.CollectionTypeSchema {
     collectionName: 'strapi_releases';
@@ -1394,6 +1426,7 @@ declare module '@strapi/strapi' {
             'api::imprint.imprint': ApiImprintImprint;
             'api::podcast.podcast': ApiPodcastPodcast;
             'api::privacy.privacy': ApiPrivacyPrivacy;
+            'api::push-subscription.push-subscription': ApiPushSubscriptionPushSubscription;
             'api::search-index.search-index': ApiSearchIndexSearchIndex;
             'plugin::content-releases.release': PluginContentReleasesRelease;
             'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -39,3 +39,6 @@ STRAPI_API_TOKEN=
 
 # Shared secret for preview authentication (must match backend STRAPI_PREVIEW_SECRET)
 STRAPI_PREVIEW_SECRET=
+
+# Web Push Notifications (VAPID — public key only, must match backend VAPID_PUBLIC_KEY)
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=

--- a/frontend/app/api/push/subscribe/route.ts
+++ b/frontend/app/api/push/subscribe/route.ts
@@ -1,0 +1,40 @@
+import {NextResponse} from 'next/server';
+
+import {getClientIp} from '@/src/lib/net/getClientIp';
+import {checkRateLimit} from '@/src/lib/security/rateLimit';
+
+const STRAPI_URL = process.env.STRAPI_URL ?? process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337';
+
+export async function POST(request: Request) {
+    const ip = getClientIp(request);
+    const rl = checkRateLimit(`push-subscribe:${ip}`, {windowMs: 60_000, max: 10});
+    if (!rl.ok) {
+        return NextResponse.json({error: 'Too many requests'}, {status: 429});
+    }
+
+    const body = await request.json().catch(() => null);
+    if (!body?.endpoint || !body?.keys?.p256dh || !body?.keys?.auth) {
+        return NextResponse.json({error: 'Invalid subscription object'}, {status: 400});
+    }
+
+    const pushSecret = process.env.PUSH_NOTIFICATION_SECRET;
+    if (!pushSecret) {
+        return NextResponse.json({error: 'Push not configured'}, {status: 500});
+    }
+
+    try {
+        const strapiResponse = await fetch(`${STRAPI_URL}/api/push-subscriptions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-m10z-push-secret': pushSecret,
+            },
+            body: JSON.stringify(body),
+        });
+
+        const data = await strapiResponse.json().catch(() => null);
+        return NextResponse.json(data ?? {}, {status: strapiResponse.status});
+    } catch {
+        return NextResponse.json({error: 'Failed to register subscription'}, {status: 502});
+    }
+}

--- a/frontend/app/api/push/unsubscribe/route.ts
+++ b/frontend/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,39 @@
+import {NextResponse} from 'next/server';
+
+import {getClientIp} from '@/src/lib/net/getClientIp';
+import {checkRateLimit} from '@/src/lib/security/rateLimit';
+
+const STRAPI_URL = process.env.STRAPI_URL ?? process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337';
+
+export async function DELETE(request: Request) {
+    const ip = getClientIp(request);
+    const rl = checkRateLimit(`push-unsubscribe:${ip}`, {windowMs: 60_000, max: 10});
+    if (!rl.ok) {
+        return NextResponse.json({error: 'Too many requests'}, {status: 429});
+    }
+
+    const body = await request.json().catch(() => null);
+    if (!body?.endpoint) {
+        return NextResponse.json({error: 'Missing endpoint'}, {status: 400});
+    }
+
+    const pushSecret = process.env.PUSH_NOTIFICATION_SECRET;
+    if (!pushSecret) {
+        return NextResponse.json({error: 'Push not configured'}, {status: 500});
+    }
+
+    try {
+        const strapiResponse = await fetch(`${STRAPI_URL}/api/push-subscriptions`, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-m10z-push-secret': pushSecret,
+            },
+            body: JSON.stringify(body),
+        });
+
+        return new NextResponse(null, {status: strapiResponse.status});
+    } catch {
+        return NextResponse.json({error: 'Failed to unregister subscription'}, {status: 502});
+    }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -33,6 +33,7 @@ export const metadata: Metadata = {
             ],
         },
     },
+    manifest: '/manifest.json',
     openGraph: {
         type: 'website',
         locale: OG_LOCALE,

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -134,6 +134,10 @@ const nextConfig: NextConfig = {
                 ...(strapiOriginForCsp ? [strapiOriginForCsp] : []),
                 // Podlove player fetches its chunk manifest/assets from the CDN.
                 ...PODLOVE_CDN_HOSTS,
+                // Web Push notification service endpoints (Firefox, Chrome, Edge).
+                '*.push.services.mozilla.com',
+                '*.notify.windows.com',
+                'fcm.googleapis.com',
             ]).join(' ')}`,
             `media-src ${unique([
                 "'self'",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,8 @@
+{
+    "name": "Mindestens 10 Zeichen",
+    "short_name": "M10Z",
+    "start_url": "/",
+    "display": "minimal-ui",
+    "background_color": "#ffffff",
+    "theme_color": "#ff6b35"
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,42 @@
+// Service Worker for push notifications
+// No caching or offline support — push events only.
+
+self.addEventListener('push', (event) => {
+    let data;
+    try {
+        data = event.data ? event.data.json() : {};
+    } catch {
+        data = {};
+    }
+
+    const title = data.title || 'M10Z';
+    const options = {
+        body: data.body || '',
+        icon: data.icon || '/icon-192.png',
+        badge: '/icon-192.png',
+        data: {
+            url: data.url || '/',
+        },
+    };
+
+    event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+
+    const url = event.notification.data?.url || '/';
+
+    event.waitUntil(
+        clients.matchAll({type: 'window', includeUncontrolled: true}).then((windowClients) => {
+            // If a window tab matching the URL exists, focus it
+            for (const client of windowClients) {
+                if (client.url === url && 'focus' in client) {
+                    return client.focus();
+                }
+            }
+            // Otherwise open a new window
+            return clients.openWindow(url);
+        }),
+    );
+});

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,6 +5,7 @@ import React, {Suspense} from 'react';
 import HeaderClient from './HeaderClient';
 import LogoClient from './LogoClient';
 import {SearchLauncher} from './SearchLauncher';
+import {NotificationToggle} from './NotificationToggle';
 import styles from './Header.module.css';
 import {routes} from '@/src/lib/routes';
 
@@ -60,6 +61,7 @@ export default function Header(): React.ReactElement {
 
                 <div className={styles.actions}>
                     <SearchLauncher />
+                    <NotificationToggle />
                     <Suspense
                         fallback={
                             <div className={styles.burgerFallback} aria-hidden>

--- a/frontend/src/components/NotificationToggle.module.css
+++ b/frontend/src/components/NotificationToggle.module.css
@@ -1,0 +1,35 @@
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 10px;
+    min-width: 42px;
+    height: 42px;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    cursor: pointer;
+    transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
+    color: var(--color-text-muted);
+}
+
+.button:hover {
+    border-color: var(--color-primary);
+    color: var(--color-text);
+}
+
+.button:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.active {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    background: var(--color-surface-strong);
+}
+
+.active:hover {
+    color: var(--color-primary-strong);
+    border-color: var(--color-primary-strong);
+}

--- a/frontend/src/components/NotificationToggle.tsx
+++ b/frontend/src/components/NotificationToggle.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import {useCallback, useEffect, useState, useSyncExternalStore} from 'react';
+import {Bell, BellSlash} from '@phosphor-icons/react/dist/ssr';
+
+import {isPushSupported, getSubscriptionStatus, subscribeToPush, unsubscribeFromPush} from '@/src/lib/pushNotifications';
+
+import styles from './NotificationToggle.module.css';
+
+const subscribeNoop = () => () => {};
+const getIsClient = () => true;
+const getIsClientServer = () => false;
+
+export function NotificationToggle() {
+    const hydrated = useSyncExternalStore(subscribeNoop, getIsClient, getIsClientServer);
+    const [subscribed, setSubscribed] = useState(false);
+    const [supported, setSupported] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        setSupported(isPushSupported());
+        setSubscribed(getSubscriptionStatus());
+    }, []);
+
+    const toggle = useCallback(async () => {
+        if (loading) return;
+        setLoading(true);
+        try {
+            if (subscribed) {
+                const ok = await unsubscribeFromPush();
+                if (ok) setSubscribed(false);
+            } else {
+                const ok = await subscribeToPush();
+                if (ok) setSubscribed(true);
+            }
+        } finally {
+            setLoading(false);
+        }
+    }, [subscribed, loading]);
+
+    if (!hydrated || !supported) return null;
+
+    return (
+        <button
+            type="button"
+            className={`${styles.button} ${subscribed ? styles.active : ''}`}
+            onClick={toggle}
+            disabled={loading}
+            aria-label={subscribed ? 'Push-Benachrichtigungen deaktivieren' : 'Push-Benachrichtigungen aktivieren'}
+            data-umami-event={subscribed ? 'push-unsubscribe' : 'push-subscribe'}
+        >
+            {subscribed ? <Bell size={18} weight="fill" /> : <BellSlash size={18} />}
+        </button>
+    );
+}

--- a/frontend/src/lib/pushNotifications.ts
+++ b/frontend/src/lib/pushNotifications.ts
@@ -1,0 +1,129 @@
+const PUSH_SUBSCRIBED_KEY = 'm10z_push_subscribed';
+const PUSH_SECRET_HEADER = 'x-m10z-push-secret';
+
+function getPushSecret(): string | null {
+    // In production, this would come from a secure source.
+    // For now, the API proxy routes use a server-side secret so the client
+    // never needs to know it.
+    return null;
+}
+
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+        return null;
+    }
+
+    try {
+        const registration = await navigator.serviceWorker.register('/sw.js', {
+            scope: '/',
+        });
+        return registration;
+    } catch {
+        return null;
+    }
+}
+
+export async function subscribeToPush(): Promise<boolean> {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+        return false;
+    }
+
+    try {
+        const registration = await registerServiceWorker();
+        if (!registration) return false;
+
+        // Request notification permission
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') return false;
+
+        const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+        if (!vapidPublicKey) return false;
+
+        const subscription = await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(vapidPublicKey) as unknown as BufferSource,
+        });
+
+        // Send subscription to backend
+        const response = await fetch('/api/push/subscribe', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(subscription.toJSON()),
+        });
+
+        if (!response.ok) return false;
+
+        try {
+            localStorage.setItem(PUSH_SUBSCRIBED_KEY, 'true');
+        } catch {
+            // Ignore localStorage errors
+        }
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export async function unsubscribeFromPush(): Promise<boolean> {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+        return false;
+    }
+
+    try {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
+        if (!subscription) return true;
+
+        // Notify backend
+        await fetch('/api/push/unsubscribe', {
+            method: 'DELETE',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(subscription.toJSON()),
+        }).catch(() => {
+            // Ignore network errors during unsubscribe
+        });
+
+        await subscription.unsubscribe();
+
+        try {
+            localStorage.removeItem(PUSH_SUBSCRIBED_KEY);
+        } catch {
+            // Ignore localStorage errors
+        }
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export function getSubscriptionStatus(): boolean {
+    try {
+        return localStorage.getItem(PUSH_SUBSCRIBED_KEY) === 'true';
+    } catch {
+        return false;
+    }
+}
+
+export function isPushSupported(): boolean {
+    return (
+        typeof window !== 'undefined' &&
+        'serviceWorker' in navigator &&
+        'PushManager' in window &&
+        'Notification' in window
+    );
+}
+
+/**
+ * Convert a base64-encoded URL-safe string to a Uint8Array.
+ * Required for the applicationServerKey parameter in pushManager.subscribe().
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+    const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const rawData = atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+    for (let i = 0; i < rawData.length; i++) {
+        outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+}


### PR DESCRIPTION
Closes #564

## Summary

Implements Web Push Protocol notifications using VAPID keys, storing subscriptions in a new Strapi content type and dispatching when content is published.

## Changes

### Backend (Strapi)
- **New content type**: `push-subscription` stores endpoint + keys per subscriber
- **Custom routes**: `POST /api/push-subscriptions` (subscribe) and `DELETE /api/push-subscriptions` (unsubscribe), authenticated via `x-m10z-push-secret` header
- **Push dispatch service**: `pushNotificationService.ts` sends notifications to all subscriptions, cleans up stale (410/404) endpoints
- **Middleware integration**: fire-and-forget push dispatch on `publish` actions for articles and podcasts

### Frontend
- **Service worker** (`public/sw.js`): handles `push` events (show notification) and `notificationclick` events (open URL)
- **Push library** (`src/lib/pushNotifications.ts`): `registerServiceWorker`, `subscribeToPush`, `unsubscribeFromPush`, `isPushSupported`
- **API proxy routes**: `/api/push/subscribe` and `/api/push/unsubscribe` forward to Strapi with server-side secret
- **NotificationToggle component**: bell icon in Header, three states (unsupported→hidden, unsubscribed→outline, subscribed→filled)
- **Web app manifest**: `public/manifest.json` for push notification support

### Configuration
- CSP: added `*.push.services.mozilla.com`, `*.notify.windows.com`, `fcm.googleapis.com` to `connect-src`
- Env vars: `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (frontend), `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`, `PUSH_NOTIFICATION_SECRET` (backend)

## Verification

- `npx tsc --noEmit` passes (frontend + backend)
- `pnpm run test:run` passes (591 tests)
- `pnpm run build` succeeds