### PR TITLE
Add /apps routes with wichteln game

### DIFF
--- a/frontend/app/apps/page.module.css
+++ b/frontend/app/apps/page.module.css
@@ -1,0 +1,60 @@
+.header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 24px;
+    margin-top: 24px;
+}
+
+.title {
+    font-size: 28px;
+    line-height: 1.2;
+    margin: 0;
+}
+
+.subtitle {
+    color: var(--color-text-muted);
+    margin: 0;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
+    gap: 16px;
+}
+
+.cardLink {
+    color: inherit;
+    text-decoration: none;
+}
+
+.cardLink:hover {
+    color: inherit;
+}
+
+.cardBody {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.cardTitle {
+    margin: 0;
+    font-size: 20px;
+    line-height: 1.3;
+}
+
+.cardDescription {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.cardAction {
+    margin-top: 8px;
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--color-primary);
+}

--- a/frontend/app/apps/page.tsx
+++ b/frontend/app/apps/page.tsx
@@ -22,7 +22,7 @@ const APPS = [
         title: 'Wichteln',
         description:
             'Organisiere deine Wichtelrunde: Teilnehmer verwalten, zufällig zuordnen und Ergebnisse als Markdown exportieren.',
-        href: '/apps/wichteln',
+        href: routes.wichteln,
     },
 ] as const;
 

--- a/frontend/app/apps/page.tsx
+++ b/frontend/app/apps/page.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import {type Metadata} from 'next';
+
+import {Card} from '@/src/components/Card';
+import {routes} from '@/src/lib/routes';
+
+import styles from './page.module.css';
+
+export const metadata: Metadata = {
+    title: 'Apps',
+    description:
+        'Kleine Werkzeuge und Spielereien rund um M10Z — Wichteln, Zufallsgeneratoren und mehr.',
+    openGraph: {
+        title: 'Apps – M10Z',
+        description:
+            'Kleine Werkzeuge und Spielereien rund um M10Z — Wichteln, Zufallsgeneratoren und mehr.',
+    },
+};
+
+const APPS = [
+    {
+        title: 'Wichteln',
+        description:
+            'Organisiere deine Wichtelrunde: Teilnehmer verwalten, zufällig zuordnen und Ergebnisse als Markdown exportieren.',
+        href: '/apps/wichteln',
+    },
+] as const;
+
+export default function AppsPage() {
+    return (
+        <div>
+            <header className={styles.header}>
+                <h1 className={styles.title}>Apps</h1>
+                <p className={styles.subtitle}>
+                    Kleine Werkzeuge und Spielereien rund um M10Z
+                </p>
+            </header>
+
+            <div className={styles.grid}>
+                {APPS.map((app) => (
+                    <Link key={app.href} href={app.href} className={styles.cardLink}>
+                        <Card>
+                            <div className={styles.cardBody}>
+                                <h2 className={styles.cardTitle}>{app.title}</h2>
+                                <p className={styles.cardDescription}>{app.description}</p>
+                                <span className={styles.cardAction}>Öffnen →</span>
+                            </div>
+                        </Card>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/apps/wichteln/page.module.css
+++ b/frontend/app/apps/wichteln/page.module.css
@@ -1,0 +1,235 @@
+.page {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 24px;
+}
+
+.title {
+    font-size: 28px;
+    line-height: 1.2;
+    margin: 0;
+}
+
+.subtitle {
+    color: var(--color-text-muted);
+    margin: 0;
+}
+
+.errorBanner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--color-primary-soft);
+    border: 1px solid var(--color-primary);
+    border-radius: var(--border-radius);
+    color: var(--color-text);
+    font-size: 14px;
+}
+
+.errorClose {
+    background: none;
+    border: none;
+    color: var(--color-text);
+    font-size: 20px;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+}
+
+.errorClose:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sectionTitle {
+    margin: 0;
+    font-size: 20px;
+    line-height: 1.3;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.formActions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.participantList {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.participantItem {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+}
+
+.participantInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.participantName {
+    font-weight: 600;
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.participantSteam {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.participantSteam:hover {
+    color: var(--color-link);
+}
+
+.participantActions {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.actionButton {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background-color 180ms ease, border-color 180ms ease;
+}
+
+.actionButton:hover {
+    background: var(--color-surface-strong);
+    border-color: var(--color-text-muted);
+}
+
+.actionButton:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.actionButtonDanger {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--color-primary);
+    cursor: pointer;
+    transition: background-color 180ms ease, border-color 180ms ease;
+}
+
+.actionButtonDanger:hover {
+    background: var(--color-primary-soft);
+    border-color: var(--color-primary);
+}
+
+.actionButtonDanger:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.actionGroup {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.hint {
+    margin: 0;
+    font-size: 13px;
+    color: var(--color-text-muted);
+}
+
+.assignmentList {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.assignmentItem {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    font-size: 14px;
+}
+
+.assignmentGiver {
+    font-weight: 600;
+}
+
+.assignmentArrow {
+    color: var(--color-text-muted);
+}
+
+.assignmentReceiver {
+    color: var(--color-text-muted);
+}
+
+@media (max-width: 767px) {
+    .participantItem {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .participantActions {
+        width: 100%;
+    }
+
+    .actionGroup {
+        flex-direction: column;
+    }
+
+    .actionGroup > * {
+        width: 100%;
+    }
+}

--- a/frontend/app/apps/wichteln/page.tsx
+++ b/frontend/app/apps/wichteln/page.tsx
@@ -8,7 +8,7 @@ import {EmptyState} from '@/src/components/EmptyState';
 import {getItem, setItem, removeItem} from '@/src/lib/storage/localStorage';
 import {shuffleAndAssign} from '@/src/lib/wichteln/shuffle';
 import {downloadMarkdown} from '@/src/lib/wichteln/export';
-import {validateName, validateSteamUrl} from '@/src/lib/wichteln/validation';
+import {validateName, validateProfileUrl} from '@/src/lib/wichteln/validation';
 import {type Participant, type Assignment} from './types';
 
 import styles from './page.module.css';
@@ -21,8 +21,16 @@ const getIsClientServer = () => false;
 
 type FormErrors = {
     name?: string | null;
-    steamUrl?: string | null;
+    profileUrl?: string | null;
 };
+
+function migrateParticipant(p: Record<string, unknown>): Participant {
+    return {
+        id: String(p.id ?? crypto.randomUUID()),
+        name: String(p.name ?? ''),
+        profileUrl: String(p.profileUrl ?? p.steamProfileUrl ?? ''),
+    };
+}
 
 export default function WichtelnPage() {
     const hydrated = useSyncExternalStore(subscribeNoop, getIsClient, getIsClientServer);
@@ -30,7 +38,7 @@ export default function WichtelnPage() {
     const [assignments, setAssignments] = useState<Assignment[]>([]);
     const [isShuffling, setIsShuffling] = useState(false);
     const [newName, setNewName] = useState('');
-    const [newSteamUrl, setNewSteamUrl] = useState('');
+    const [newProfileUrl, setNewProfileUrl] = useState('');
     const [editingId, setEditingId] = useState<string | null>(null);
     const [formErrors, setFormErrors] = useState<FormErrors>({});
     const [error, setError] = useState<string | null>(null);
@@ -38,16 +46,16 @@ export default function WichtelnPage() {
     useEffect(() => {
         if (!hydrated) return;
         try {
-            const state = getItem<{
-                participants: Participant[];
-                assignments: Assignment[];
+            const raw = getItem<{
+                participants?: Record<string, unknown>[];
+                assignments?: Assignment[];
             }>(STORAGE_KEY);
-            if (state) {
-                if (Array.isArray(state.participants)) {
-                    setParticipants(state.participants);
+            if (raw) {
+                if (Array.isArray(raw.participants)) {
+                    setParticipants(raw.participants.map(migrateParticipant));
                 }
-                if (Array.isArray(state.assignments)) {
-                    setAssignments(state.assignments);
+                if (Array.isArray(raw.assignments)) {
+                    setAssignments(raw.assignments);
                 }
             }
         } catch {
@@ -78,45 +86,44 @@ export default function WichtelnPage() {
     const addParticipant = useCallback(() => {
         clearError();
         const nameError = validateName(newName);
-        const steamError = validateSteamUrl(newSteamUrl);
-        setFormErrors({name: nameError, steamUrl: steamError});
-        if (nameError) return;
+        const profileError = validateProfileUrl(newProfileUrl);
+        setFormErrors({name: nameError, profileUrl: profileError});
+        if (nameError || profileError) return;
 
         const participant: Participant = {
             id: crypto.randomUUID(),
             name: newName.trim(),
-            steamProfileUrl: newSteamUrl.trim(),
+            profileUrl: newProfileUrl.trim(),
         };
         const updated = [...participants, participant];
         setParticipants(updated);
         setAssignments([]);
         persist(updated, []);
         setNewName('');
-        setNewSteamUrl('');
+        setNewProfileUrl('');
         setEditingId(null);
-    }, [newName, newSteamUrl, participants, persist, clearError]);
+    }, [newName, newProfileUrl, participants, persist, clearError]);
 
     const updateParticipant = useCallback(
         (id: string) => {
             clearError();
             const nameError = validateName(newName);
-            const steamError = validateSteamUrl(newSteamUrl);
-            setFormErrors({name: nameError, steamUrl: steamError});
-            if (nameError) return;
+            const profileError = validateProfileUrl(newProfileUrl);
+            setFormErrors({name: nameError, profileUrl: profileError});
+            if (nameError || profileError) return;
 
             const updated = participants.map((p) =>
                 p.id === id
-                    ? {...p, name: newName.trim(), steamProfileUrl: newSteamUrl.trim()}
+                    ? {...p, name: newName.trim(), profileUrl: newProfileUrl.trim()}
                     : p
             );
             setParticipants(updated);
-            setAssignments([]);
-            persist(updated, []);
+            persist(updated, assignments);
             setNewName('');
-            setNewSteamUrl('');
+            setNewProfileUrl('');
             setEditingId(null);
         },
-        [newName, newSteamUrl, participants, persist, clearError]
+        [newName, newProfileUrl, participants, assignments, persist, clearError]
     );
 
     const deleteParticipant = useCallback(
@@ -129,7 +136,7 @@ export default function WichtelnPage() {
             if (editingId === id) {
                 setEditingId(null);
                 setNewName('');
-                setNewSteamUrl('');
+                setNewProfileUrl('');
                 setFormErrors({});
             }
         },
@@ -140,7 +147,7 @@ export default function WichtelnPage() {
         (participant: Participant) => {
             setEditingId(participant.id);
             setNewName(participant.name);
-            setNewSteamUrl(participant.steamProfileUrl);
+            setNewProfileUrl(participant.profileUrl);
             setFormErrors({});
         },
         []
@@ -149,7 +156,7 @@ export default function WichtelnPage() {
     const cancelEdit = useCallback(() => {
         setEditingId(null);
         setNewName('');
-        setNewSteamUrl('');
+        setNewProfileUrl('');
         setFormErrors({});
     }, []);
 
@@ -192,7 +199,7 @@ export default function WichtelnPage() {
         setAssignments([]);
         setEditingId(null);
         setNewName('');
-        setNewSteamUrl('');
+        setNewProfileUrl('');
         setFormErrors({});
         removeItem(STORAGE_KEY);
     }, []);
@@ -254,25 +261,25 @@ export default function WichtelnPage() {
                         error={formErrors.name}
                     />
                     <Input
-                        id="wichteln-steam-url"
-                        label="Steam-Profil-URL"
+                        id="wichteln-profile-url"
+                        label="Profil-URL (Steam / GOG)"
                         type="url"
-                        value={newSteamUrl}
+                        value={newProfileUrl}
                         onChange={(v) => {
-                            setNewSteamUrl(v);
+                            setNewProfileUrl(v);
                             setFormErrors((prev) => ({
                                 ...prev,
-                                steamUrl: validateSteamUrl(v),
+                                profileUrl: validateProfileUrl(v),
                             }));
                         }}
-                        placeholder="https://steamcommunity.com/id/..."
-                        error={formErrors.steamUrl}
+                        placeholder="https://steamcommunity.com/id/... oder https://www.gog.com/u/..."
+                        error={formErrors.profileUrl}
                     />
                     <div className={styles.formActions}>
                         <Button
                             type="submit"
                             variant="primary"
-                            disabled={!!formErrors.name}
+                            disabled={!!formErrors.name || !!formErrors.profileUrl}
                         >
                             {editingId ? 'Speichern' : 'Hinzufügen'}
                         </Button>
@@ -303,14 +310,14 @@ export default function WichtelnPage() {
                                     <span className={styles.participantName}>
                                         {p.name}
                                     </span>
-                                    {p.steamProfileUrl && (
+                                    {p.profileUrl && (
                                         <a
-                                            href={p.steamProfileUrl}
+                                            href={p.profileUrl}
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             className={styles.participantSteam}
                                         >
-                                            Steam-Profil
+                                            Profil
                                         </a>
                                     )}
                                 </div>
@@ -382,26 +389,25 @@ export default function WichtelnPage() {
                 <section className={styles.section}>
                     <h2 className={styles.sectionTitle}>Zuordnungen</h2>
                     <ul className={styles.assignmentList}>
-                        {assignments.map((a) => {
-                            const giver = participants.find(
-                                (p) => p.id === a.giverId
-                            );
-                            const receiver = participants.find(
-                                (p) => p.id === a.receiverId
-                            );
-                            if (!giver || !receiver) return null;
-                            return (
-                                <li key={a.giverId} className={styles.assignmentItem}>
-                                    <span className={styles.assignmentGiver}>
-                                        {giver.name}
-                                    </span>
-                                    <span className={styles.assignmentArrow}>→</span>
-                                    <span className={styles.assignmentReceiver}>
-                                        {receiver.name}
-                                    </span>
-                                </li>
-                            );
-                        })}
+                        {(() => {
+                            const participantMap = new Map(participants.map((p) => [p.id, p]));
+                            return assignments.map((a) => {
+                                const giver = participantMap.get(a.giverId);
+                                const receiver = participantMap.get(a.receiverId);
+                                if (!giver || !receiver) return null;
+                                return (
+                                    <li key={a.giverId} className={styles.assignmentItem}>
+                                        <span className={styles.assignmentGiver}>
+                                            {giver.name}
+                                        </span>
+                                        <span className={styles.assignmentArrow}>→</span>
+                                        <span className={styles.assignmentReceiver}>
+                                            {receiver.name}
+                                        </span>
+                                    </li>
+                                );
+                            });
+                        })()}
                     </ul>
                 </section>
             )}

--- a/frontend/app/apps/wichteln/page.tsx
+++ b/frontend/app/apps/wichteln/page.tsx
@@ -1,0 +1,410 @@
+'use client';
+
+import {useCallback, useEffect, useState, useSyncExternalStore} from 'react';
+
+import {Button} from '@/src/components/Button/Button';
+import {Input} from '@/src/components/Input/Input';
+import {EmptyState} from '@/src/components/EmptyState';
+import {getItem, setItem, removeItem} from '@/src/lib/storage/localStorage';
+import {shuffleAndAssign} from '@/src/lib/wichteln/shuffle';
+import {downloadMarkdown} from '@/src/lib/wichteln/export';
+import {validateName, validateSteamUrl} from '@/src/lib/wichteln/validation';
+import {type Participant, type Assignment} from './types';
+
+import styles from './page.module.css';
+
+const STORAGE_KEY = 'm10z-wichteln-state';
+
+const subscribeNoop = () => () => {};
+const getIsClient = () => true;
+const getIsClientServer = () => false;
+
+type FormErrors = {
+    name?: string | null;
+    steamUrl?: string | null;
+};
+
+export default function WichtelnPage() {
+    const hydrated = useSyncExternalStore(subscribeNoop, getIsClient, getIsClientServer);
+    const [participants, setParticipants] = useState<Participant[]>([]);
+    const [assignments, setAssignments] = useState<Assignment[]>([]);
+    const [isShuffling, setIsShuffling] = useState(false);
+    const [newName, setNewName] = useState('');
+    const [newSteamUrl, setNewSteamUrl] = useState('');
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [formErrors, setFormErrors] = useState<FormErrors>({});
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!hydrated) return;
+        try {
+            const state = getItem<{
+                participants: Participant[];
+                assignments: Assignment[];
+            }>(STORAGE_KEY);
+            if (state) {
+                if (Array.isArray(state.participants)) {
+                    setParticipants(state.participants);
+                }
+                if (Array.isArray(state.assignments)) {
+                    setAssignments(state.assignments);
+                }
+            }
+        } catch {
+            removeItem(STORAGE_KEY);
+        }
+    }, [hydrated]);
+
+    const persist = useCallback(
+        (
+            newParticipants: Participant[],
+            newAssignments: Assignment[]
+        ) => {
+            try {
+                setItem(STORAGE_KEY, {
+                    participants: newParticipants,
+                    assignments: newAssignments,
+                    timestamp: Date.now(),
+                });
+            } catch {
+                setError('Fehler beim Speichern. Speicher könnte voll sein.');
+            }
+        },
+        []
+    );
+
+    const clearError = useCallback(() => setError(null), []);
+
+    const addParticipant = useCallback(() => {
+        clearError();
+        const nameError = validateName(newName);
+        const steamError = validateSteamUrl(newSteamUrl);
+        setFormErrors({name: nameError, steamUrl: steamError});
+        if (nameError) return;
+
+        const participant: Participant = {
+            id: crypto.randomUUID(),
+            name: newName.trim(),
+            steamProfileUrl: newSteamUrl.trim(),
+        };
+        const updated = [...participants, participant];
+        setParticipants(updated);
+        setAssignments([]);
+        persist(updated, []);
+        setNewName('');
+        setNewSteamUrl('');
+        setEditingId(null);
+    }, [newName, newSteamUrl, participants, persist, clearError]);
+
+    const updateParticipant = useCallback(
+        (id: string) => {
+            clearError();
+            const nameError = validateName(newName);
+            const steamError = validateSteamUrl(newSteamUrl);
+            setFormErrors({name: nameError, steamUrl: steamError});
+            if (nameError) return;
+
+            const updated = participants.map((p) =>
+                p.id === id
+                    ? {...p, name: newName.trim(), steamProfileUrl: newSteamUrl.trim()}
+                    : p
+            );
+            setParticipants(updated);
+            setAssignments([]);
+            persist(updated, []);
+            setNewName('');
+            setNewSteamUrl('');
+            setEditingId(null);
+        },
+        [newName, newSteamUrl, participants, persist, clearError]
+    );
+
+    const deleteParticipant = useCallback(
+        (id: string) => {
+            clearError();
+            const updated = participants.filter((p) => p.id !== id);
+            setParticipants(updated);
+            setAssignments([]);
+            persist(updated, []);
+            if (editingId === id) {
+                setEditingId(null);
+                setNewName('');
+                setNewSteamUrl('');
+                setFormErrors({});
+            }
+        },
+        [participants, persist, editingId, clearError]
+    );
+
+    const startEdit = useCallback(
+        (participant: Participant) => {
+            setEditingId(participant.id);
+            setNewName(participant.name);
+            setNewSteamUrl(participant.steamProfileUrl);
+            setFormErrors({});
+        },
+        []
+    );
+
+    const cancelEdit = useCallback(() => {
+        setEditingId(null);
+        setNewName('');
+        setNewSteamUrl('');
+        setFormErrors({});
+    }, []);
+
+    const handleShuffle = useCallback(() => {
+        clearError();
+        if (participants.length < 2) {
+            setError('Mindestens 2 Teilnehmer für die Zuordnung erforderlich.');
+            return;
+        }
+        setIsShuffling(true);
+        try {
+            const result = shuffleAndAssign(participants);
+            setAssignments(result);
+            persist(participants, result);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Zuordnung fehlgeschlagen.');
+        } finally {
+            setIsShuffling(false);
+        }
+    }, [participants, persist, clearError]);
+
+    const handleExport = useCallback(() => {
+        try {
+            downloadMarkdown(participants, assignments);
+        } catch {
+            setError('Export fehlgeschlagen.');
+        }
+    }, [participants, assignments]);
+
+    const handleResetAssignments = useCallback(() => {
+        if (!confirm('Zuordnungen zurücksetzen?')) return;
+        setAssignments([]);
+        persist(participants, []);
+    }, [participants, persist]);
+
+    const handleClearAll = useCallback(() => {
+        if (!confirm('Alle Daten löschen? Dies kann nicht rückgängig gemacht werden.'))
+            return;
+        setParticipants([]);
+        setAssignments([]);
+        setEditingId(null);
+        setNewName('');
+        setNewSteamUrl('');
+        setFormErrors({});
+        removeItem(STORAGE_KEY);
+    }, []);
+
+    if (!hydrated) return null;
+
+    return (
+        <div className={styles.page}>
+            <header className={styles.header}>
+                <h1 className={styles.title}>Wichteln</h1>
+                <p className={styles.subtitle}>
+                    Organisiere deine Wichtelrunde — Teilnehmer verwalten,
+                    zufällig zuordnen und Ergebnisse exportieren.
+                </p>
+            </header>
+
+            {error && (
+                <div className={styles.errorBanner} role="alert">
+                    {error}
+                    <button
+                        type="button"
+                        className={styles.errorClose}
+                        onClick={clearError}
+                        aria-label="Schließen"
+                    >
+                        ×
+                    </button>
+                </div>
+            )}
+
+            <section className={styles.section}>
+                <h2 className={styles.sectionTitle}>
+                    {editingId ? 'Teilnehmer bearbeiten' : 'Teilnehmer hinzufügen'}
+                </h2>
+                <form
+                    className={styles.form}
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        if (editingId) {
+                            updateParticipant(editingId);
+                        } else {
+                            addParticipant();
+                        }
+                    }}
+                >
+                    <Input
+                        id="wichteln-name"
+                        label="Name"
+                        value={newName}
+                        onChange={(v) => {
+                            setNewName(v);
+                            setFormErrors((prev) => ({
+                                ...prev,
+                                name: validateName(v),
+                            }));
+                        }}
+                        placeholder="z.B. Max Mustermann"
+                        required
+                        error={formErrors.name}
+                    />
+                    <Input
+                        id="wichteln-steam-url"
+                        label="Steam-Profil-URL"
+                        type="url"
+                        value={newSteamUrl}
+                        onChange={(v) => {
+                            setNewSteamUrl(v);
+                            setFormErrors((prev) => ({
+                                ...prev,
+                                steamUrl: validateSteamUrl(v),
+                            }));
+                        }}
+                        placeholder="https://steamcommunity.com/id/..."
+                        error={formErrors.steamUrl}
+                    />
+                    <div className={styles.formActions}>
+                        <Button
+                            type="submit"
+                            variant="primary"
+                            disabled={!!formErrors.name}
+                        >
+                            {editingId ? 'Speichern' : 'Hinzufügen'}
+                        </Button>
+                        {editingId && (
+                            <Button
+                                variant="secondary"
+                                onClick={cancelEdit}
+                                type="button"
+                            >
+                                Abbrechen
+                            </Button>
+                        )}
+                    </div>
+                </form>
+            </section>
+
+            <section className={styles.section}>
+                <h2 className={styles.sectionTitle}>
+                    Teilnehmer ({participants.length})
+                </h2>
+                {participants.length === 0 ? (
+                    <EmptyState message="Füge den ersten Teilnehmer hinzu, um zu starten." />
+                ) : (
+                    <ul className={styles.participantList}>
+                        {participants.map((p) => (
+                            <li key={p.id} className={styles.participantItem}>
+                                <div className={styles.participantInfo}>
+                                    <span className={styles.participantName}>
+                                        {p.name}
+                                    </span>
+                                    {p.steamProfileUrl && (
+                                        <a
+                                            href={p.steamProfileUrl}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className={styles.participantSteam}
+                                        >
+                                            Steam-Profil
+                                        </a>
+                                    )}
+                                </div>
+                                <div className={styles.participantActions}>
+                                    <button
+                                        type="button"
+                                        className={styles.actionButton}
+                                        onClick={() => startEdit(p)}
+                                        aria-label={`${p.name} bearbeiten`}
+                                    >
+                                        Bearbeiten
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className={styles.actionButtonDanger}
+                                        onClick={() => deleteParticipant(p.id)}
+                                        aria-label={`${p.name} löschen`}
+                                    >
+                                        Löschen
+                                    </button>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+
+            <section className={styles.section}>
+                <h2 className={styles.sectionTitle}>Aktionen</h2>
+                <div className={styles.actionGroup}>
+                    <Button
+                        variant="primary"
+                        onClick={handleShuffle}
+                        disabled={participants.length < 2}
+                        loading={isShuffling}
+                    >
+                        Shuffle &amp; Zuordnen
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={handleExport}
+                        disabled={assignments.length === 0}
+                    >
+                        Als Markdown exportieren
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={handleResetAssignments}
+                        disabled={assignments.length === 0}
+                    >
+                        Zuordnungen zurücksetzen
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={handleClearAll}
+                        disabled={participants.length === 0 && assignments.length === 0}
+                    >
+                        Alle Daten löschen
+                    </Button>
+                </div>
+                {participants.length < 2 && (
+                    <p className={styles.hint}>
+                        Mindestens 2 Teilnehmer für die Zuordnung erforderlich.
+                    </p>
+                )}
+            </section>
+
+            {assignments.length > 0 && (
+                <section className={styles.section}>
+                    <h2 className={styles.sectionTitle}>Zuordnungen</h2>
+                    <ul className={styles.assignmentList}>
+                        {assignments.map((a) => {
+                            const giver = participants.find(
+                                (p) => p.id === a.giverId
+                            );
+                            const receiver = participants.find(
+                                (p) => p.id === a.receiverId
+                            );
+                            if (!giver || !receiver) return null;
+                            return (
+                                <li key={a.giverId} className={styles.assignmentItem}>
+                                    <span className={styles.assignmentGiver}>
+                                        {giver.name}
+                                    </span>
+                                    <span className={styles.assignmentArrow}>→</span>
+                                    <span className={styles.assignmentReceiver}>
+                                        {receiver.name}
+                                    </span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </section>
+            )}
+        </div>
+    );
+}

--- a/frontend/app/apps/wichteln/types.ts
+++ b/frontend/app/apps/wichteln/types.ts
@@ -1,7 +1,7 @@
 export type Participant = {
     id: string;
     name: string;
-    steamProfileUrl: string;
+    profileUrl: string;
 };
 
 export type Assignment = {

--- a/frontend/app/apps/wichteln/types.ts
+++ b/frontend/app/apps/wichteln/types.ts
@@ -1,0 +1,16 @@
+export type Participant = {
+    id: string;
+    name: string;
+    steamProfileUrl: string;
+};
+
+export type Assignment = {
+    giverId: string;
+    receiverId: string;
+};
+
+export type WichtelnState = {
+    participants: Participant[];
+    assignments: Assignment[];
+    timestamp: number;
+};

--- a/frontend/src/components/Button/Button.module.css
+++ b/frontend/src/components/Button/Button.module.css
@@ -1,0 +1,55 @@
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 20px;
+    border: 1px solid transparent;
+    border-radius: var(--border-radius);
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.5;
+    cursor: pointer;
+    transition: background-color 180ms ease, color 180ms ease,
+        border-color 180ms ease, opacity 180ms ease;
+}
+
+.button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.primary {
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+    border-color: var(--color-primary);
+}
+
+.primary:hover:not(:disabled) {
+    background: var(--color-primary-strong);
+    border-color: var(--color-primary-strong);
+}
+
+.primary:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.secondary {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+}
+
+.secondary:hover:not(:disabled) {
+    background: var(--color-surface-strong);
+    border-color: var(--color-text-muted);
+}
+
+.secondary:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.loading {
+    opacity: 0.7;
+}

--- a/frontend/src/components/Button/Button.tsx
+++ b/frontend/src/components/Button/Button.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import styles from './Button.module.css';
+
+type ButtonProps = {
+    children: string;
+    variant?: 'primary' | 'secondary';
+    disabled?: boolean;
+    loading?: boolean;
+    onClick?: () => void;
+    type?: 'button' | 'submit';
+};
+
+export function Button({
+    children,
+    variant = 'primary',
+    disabled = false,
+    loading = false,
+    onClick = () => {},
+    type = 'button',
+}: ButtonProps) {
+    const classes = [
+        styles.button,
+        variant === 'secondary' ? styles.secondary : styles.primary,
+        loading ? styles.loading : '',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <button
+            type={type}
+            className={classes}
+            disabled={disabled || loading}
+            onClick={onClick}
+        >
+            {loading ? 'Wird ausgeführt…' : children}
+        </button>
+    );
+}

--- a/frontend/src/components/Button/Button.tsx
+++ b/frontend/src/components/Button/Button.tsx
@@ -33,8 +33,11 @@ export function Button({
             className={classes}
             disabled={disabled || loading}
             onClick={onClick}
+            aria-busy={loading || undefined}
         >
-            {loading ? 'Wird ausgeführt…' : children}
+            <span aria-live="polite" role="status">
+                {loading ? 'Wird ausgeführt…' : children}
+            </span>
         </button>
     );
 }

--- a/frontend/src/components/Input/Input.module.css
+++ b/frontend/src/components/Input/Input.module.css
@@ -1,0 +1,48 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.required {
+    color: var(--color-primary);
+    margin-left: 2px;
+}
+
+.input {
+    padding: 10px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 14px;
+    line-height: 1.5;
+    transition: border-color 180ms ease;
+}
+
+.input::placeholder {
+    color: var(--color-text-muted);
+    opacity: 0.7;
+}
+
+.input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-primary-soft);
+}
+
+.inputError {
+    border-color: var(--color-primary);
+}
+
+.error {
+    margin: 0;
+    font-size: 12px;
+    color: var(--color-primary);
+}

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import {type ChangeEvent} from 'react';
+
+import styles from './Input.module.css';
+
+type InputProps = {
+    type?: 'text' | 'url';
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    required?: boolean;
+    label: string;
+    error?: string | null;
+    id: string;
+};
+
+export function Input({
+    type = 'text',
+    value,
+    onChange,
+    placeholder,
+    required = false,
+    label,
+    error,
+    id,
+}: InputProps) {
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        onChange(e.target.value);
+    };
+
+    return (
+        <div className={styles.wrapper}>
+            <label htmlFor={id} className={styles.label}>
+                {label}
+                {required && <span className={styles.required}>*</span>}
+            </label>
+            <input
+                id={id}
+                type={type}
+                value={value}
+                onChange={handleChange}
+                placeholder={placeholder}
+                required={required}
+                className={`${styles.input} ${error ? styles.inputError : ''}`}
+                aria-invalid={!!error}
+                aria-describedby={error ? `${id}-error` : undefined}
+            />
+            {error && (
+                <p id={`${id}-error`} className={styles.error} role="alert">
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -21,6 +21,8 @@ export const routes = {
     category: (slug: string) => `/kategorien/${slug}`,
     authors: '/team',
     author: (slug: string) => `/team/${slug}`,
+    apps: '/apps',
+    wichteln: '/apps/wichteln',
     m12g: '/m12g',
     m12gGames: '/m12g/spiele',
     m12gGame: (slug: string) => `/m12g/spiele/${slug}`,

--- a/frontend/src/lib/storage/localStorage.test.ts
+++ b/frontend/src/lib/storage/localStorage.test.ts
@@ -1,0 +1,100 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+import {getItem, removeItem, setItem} from './localStorage';
+
+describe('localStorage utilities', () => {
+    let store: Record<string, string> = {};
+
+    beforeEach(() => {
+        store = {};
+        vi.stubGlobal(
+            'window',
+            {
+                localStorage: {
+                    getItem: vi.fn((key: string) => store[key] ?? null),
+                    setItem: vi.fn((key: string, value: string) => {
+                        store[key] = value;
+                    }),
+                    removeItem: vi.fn((key: string) => {
+                        delete store[key];
+                    }),
+                },
+            }
+        );
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    describe('setItem', () => {
+        test('stores serialized value', () => {
+            setItem('key', {foo: 'bar'});
+            expect(store['key']).toBe('{"foo":"bar"}');
+        });
+
+        test('stores array', () => {
+            setItem('list', [1, 2, 3]);
+            expect(store['list']).toBe('[1,2,3]');
+        });
+
+        test('stores string', () => {
+            setItem('str', 'hello');
+            expect(store['str']).toBe('"hello"');
+        });
+    });
+
+    describe('getItem', () => {
+        test('returns parsed value', () => {
+            store['key'] = '{"foo":"bar"}';
+            expect(getItem<{foo: string}>('key')).toEqual({foo: 'bar'});
+        });
+
+        test('returns null for missing key', () => {
+            expect(getItem('nonexistent')).toBeNull();
+        });
+
+        test('returns null for corrupted JSON', () => {
+            store['bad'] = '{broken';
+            expect(getItem('bad')).toBeNull();
+        });
+    });
+
+    describe('removeItem', () => {
+        test('removes stored value', () => {
+            store['key'] = 'value';
+            removeItem('key');
+            expect(store['key']).toBeUndefined();
+        });
+
+        test('no error when removing nonexistent key', () => {
+            expect(() => removeItem('nonexistent')).not.toThrow();
+        });
+    });
+
+    describe('round-trip', () => {
+        test('set then get returns same value', () => {
+            const data = {participants: [{id: '1', name: 'Alice', steamProfileUrl: ''}]};
+            setItem('roundtrip', data);
+            const result = getItem<typeof data>('roundtrip');
+            expect(result).toEqual(data);
+        });
+    });
+
+    describe('server-side (no window)', () => {
+        beforeEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        test('setItem uses in-memory fallback', () => {
+            setItem('key', 'value');
+            expect(getItem<string>('key')).toBe('value');
+        });
+
+        test('removeItem works with in-memory fallback', () => {
+            setItem('key', 'value');
+            removeItem('key');
+            expect(getItem<string>('key')).toBeNull();
+        });
+    });
+});

--- a/frontend/src/lib/storage/localStorage.test.ts
+++ b/frontend/src/lib/storage/localStorage.test.ts
@@ -1,12 +1,13 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 
-import {getItem, removeItem, setItem} from './localStorage';
+import {clearCache, getItem, removeItem, setItem} from './localStorage';
 
 describe('localStorage utilities', () => {
     let store: Record<string, string> = {};
 
     beforeEach(() => {
         store = {};
+        clearCache();
         vi.stubGlobal(
             'window',
             {
@@ -25,6 +26,7 @@ describe('localStorage utilities', () => {
 
     afterEach(() => {
         vi.unstubAllGlobals();
+        clearCache();
     });
 
     describe('setItem', () => {
@@ -74,16 +76,51 @@ describe('localStorage utilities', () => {
 
     describe('round-trip', () => {
         test('set then get returns same value', () => {
-            const data = {participants: [{id: '1', name: 'Alice', steamProfileUrl: ''}]};
+            const data = {participants: [{id: '1', name: 'Alice', profileUrl: ''}]};
             setItem('roundtrip', data);
             const result = getItem<typeof data>('roundtrip');
             expect(result).toEqual(data);
         });
     });
 
+    describe('localStorage throws', () => {
+        beforeEach(() => {
+            clearCache();
+            vi.stubGlobal('window', {
+                localStorage: {
+                    getItem: vi.fn(() => {
+                        throw new Error('storage error');
+                    }),
+                    setItem: vi.fn(() => {
+                        throw new Error('storage error');
+                    }),
+                    removeItem: vi.fn(() => {
+                        throw new Error('storage error');
+                    }),
+                },
+            });
+        });
+
+        test('setItem uses in-memory fallback', () => {
+            setItem('key', 'value');
+            expect(getItem<string>('key')).toBe('value');
+        });
+
+        test('getItem returns null for missing key', () => {
+            expect(getItem('nonexistent')).toBeNull();
+        });
+
+        test('removeItem does not throw when localStorage fails', () => {
+            setItem('key', 'value');
+            removeItem('key');
+            expect(getItem<string>('key')).toBeNull();
+        });
+    });
+
     describe('server-side (no window)', () => {
         beforeEach(() => {
             vi.unstubAllGlobals();
+            clearCache();
         });
 
         test('setItem uses in-memory fallback', () => {

--- a/frontend/src/lib/storage/localStorage.ts
+++ b/frontend/src/lib/storage/localStorage.ts
@@ -3,37 +3,63 @@ const inMemoryStore = new Map<string, string>();
 export function getItem<T>(key: string): T | null {
     if (typeof window === 'undefined') {
         const value = inMemoryStore.get(key);
-        return value ? (JSON.parse(value) as T) : null;
+        if (value === undefined) return null;
+        try { return JSON.parse(value) as T; } catch { return null; }
     }
+
     try {
         const item = window.localStorage.getItem(key);
-        if (item === null) return null;
-        return JSON.parse(item) as T;
+        if (item !== null) {
+            inMemoryStore.set(key, item);
+            try { return JSON.parse(item) as T; } catch { return null; }
+        }
     } catch {
-        const value = inMemoryStore.get(key);
-        return value ? (JSON.parse(value) as T) : null;
+        // localStorage unavailable, fall through to in-memory
     }
+
+    const value = inMemoryStore.get(key);
+    if (value !== undefined) {
+        try { return JSON.parse(value) as T; } catch { return null; }
+    }
+
+    return null;
 }
 
 export function setItem<T>(key: string, value: T): void {
     const serialized = JSON.stringify(value);
-    if (typeof window === 'undefined') {
-        inMemoryStore.set(key, serialized);
-        return;
-    }
+    inMemoryStore.set(key, serialized);
+
+    if (typeof window === 'undefined') return;
+
     try {
         window.localStorage.setItem(key, serialized);
     } catch {
-        inMemoryStore.set(key, serialized);
+        // in-memory fallback already set
     }
 }
 
 export function removeItem(key: string): void {
     inMemoryStore.delete(key);
+
     if (typeof window === 'undefined') return;
+
     try {
         window.localStorage.removeItem(key);
     } catch {
         // ignore
     }
+}
+
+export function clearCache(): void {
+    inMemoryStore.clear();
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', (e: StorageEvent) => {
+        if (e.key) inMemoryStore.delete(e.key);
+    });
+
+    window.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') inMemoryStore.clear();
+    });
 }

--- a/frontend/src/lib/storage/localStorage.ts
+++ b/frontend/src/lib/storage/localStorage.ts
@@ -1,0 +1,39 @@
+const inMemoryStore = new Map<string, string>();
+
+export function getItem<T>(key: string): T | null {
+    if (typeof window === 'undefined') {
+        const value = inMemoryStore.get(key);
+        return value ? (JSON.parse(value) as T) : null;
+    }
+    try {
+        const item = window.localStorage.getItem(key);
+        if (item === null) return null;
+        return JSON.parse(item) as T;
+    } catch {
+        const value = inMemoryStore.get(key);
+        return value ? (JSON.parse(value) as T) : null;
+    }
+}
+
+export function setItem<T>(key: string, value: T): void {
+    const serialized = JSON.stringify(value);
+    if (typeof window === 'undefined') {
+        inMemoryStore.set(key, serialized);
+        return;
+    }
+    try {
+        window.localStorage.setItem(key, serialized);
+    } catch {
+        inMemoryStore.set(key, serialized);
+    }
+}
+
+export function removeItem(key: string): void {
+    inMemoryStore.delete(key);
+    if (typeof window === 'undefined') return;
+    try {
+        window.localStorage.removeItem(key);
+    } catch {
+        // ignore
+    }
+}

--- a/frontend/src/lib/storage/localStorage.ts
+++ b/frontend/src/lib/storage/localStorage.ts
@@ -56,7 +56,11 @@ export function clearCache(): void {
 
 if (typeof window !== 'undefined') {
     window.addEventListener('storage', (e: StorageEvent) => {
-        if (e.key) inMemoryStore.delete(e.key);
+        if (e.key === null) {
+            inMemoryStore.clear();
+        } else {
+            inMemoryStore.delete(e.key);
+        }
     });
 
     window.addEventListener('visibilitychange', () => {

--- a/frontend/src/lib/wichteln/export.test.ts
+++ b/frontend/src/lib/wichteln/export.test.ts
@@ -92,6 +92,31 @@ describe('generateMarkdown', () => {
         expect(result).not.toContain('Alice');
     });
 
+    test('escapes markdown metacharacters in names', () => {
+        const participants = makeParticipants([
+            {id: 'a', name: 'Bob [Star] *Gamer*_01'},
+            {id: 'b', name: 'Alice (Test)'},
+        ]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'b'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain('Bob \\[Star\\] \\*Gamer\\*\\_01');
+        expect(result).toContain('Alice \\(Test\\)');
+    });
+
+    test('normalizes newlines in names', () => {
+        const participants = makeParticipants([
+            {id: 'a', name: 'Bob\nSmith'},
+            {id: 'b', name: 'Alice'},
+        ]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'b'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain('Bob Smith');
+    });
+
     test('handles empty assignments', () => {
         const participants = makeParticipants([{id: 'a', name: 'Alice'}]);
         const result = generateMarkdown(participants, []);

--- a/frontend/src/lib/wichteln/export.test.ts
+++ b/frontend/src/lib/wichteln/export.test.ts
@@ -1,0 +1,89 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+
+import {generateMarkdown} from './export';
+
+import {type Participant, type Assignment} from '@/app/apps/wichteln/types';
+
+function makeParticipants(
+    overrides: Partial<Participant>[] = []
+): Participant[] {
+    return overrides.map((o, i) => ({
+        id: o.id ?? `id-${i}`,
+        name: o.name ?? `Participant ${i}`,
+        steamProfileUrl: o.steamProfileUrl ?? '',
+    }));
+}
+
+describe('generateMarkdown', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-25T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('includes header and timestamp', () => {
+        const participants = makeParticipants([{id: 'a', name: 'Alice'}]);
+        const assignments: Assignment[] = [{giverId: 'a', receiverId: 'a'}];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain('# Wichteln Ergebnisse');
+        expect(result).toContain('25. Juli 2026');
+    });
+
+    test('lists assignments as giver → receiver', () => {
+        const participants = makeParticipants([
+            {id: 'a', name: 'Alice'},
+            {id: 'b', name: 'Bob'},
+        ]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'b'},
+            {giverId: 'b', receiverId: 'a'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain('**Alice** → **Bob**');
+        expect(result).toContain('**Bob** → **Alice**');
+    });
+
+    test('includes receiver Steam URL when available', () => {
+        const participants = makeParticipants([
+            {id: 'a', name: 'Alice'},
+            {id: 'b', name: 'Bob', steamProfileUrl: 'https://steamcommunity.com/id/bob'},
+        ]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'b'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain('Steam: https://steamcommunity.com/id/bob');
+    });
+
+    test('omits Steam URL when receiver has none', () => {
+        const participants = makeParticipants([
+            {id: 'a', name: 'Alice'},
+            {id: 'b', name: 'Bob', steamProfileUrl: ''},
+        ]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'b'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain('**Alice** → **Bob**');
+        expect(result).not.toContain('Steam:');
+    });
+
+    test('skips assignment when participant is missing from map', () => {
+        const participants = makeParticipants([{id: 'a', name: 'Alice'}]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'missing'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).not.toContain('Alice');
+    });
+
+    test('handles empty assignments', () => {
+        const participants = makeParticipants([{id: 'a', name: 'Alice'}]);
+        const result = generateMarkdown(participants, []);
+        expect(result).toContain('# Wichteln Ergebnisse');
+        expect(result).not.toContain('**Alice**');
+    });
+});

--- a/frontend/src/lib/wichteln/export.test.ts
+++ b/frontend/src/lib/wichteln/export.test.ts
@@ -67,7 +67,7 @@ describe('generateMarkdown', () => {
             {giverId: 'a', receiverId: 'b'},
         ];
         const result = generateMarkdown(participants, assignments);
-        expect(result).toContain('Profil: https://www.gog.com/u/e_Lap');
+        expect(result).toContain('Profil: https://www.gog.com/u/e\\_Lap');
     });
 
     test('omits profile URL when receiver has none', () => {
@@ -115,6 +115,20 @@ describe('generateMarkdown', () => {
         ];
         const result = generateMarkdown(participants, assignments);
         expect(result).toContain('Bob Smith');
+    });
+
+    test('escapes markdown metacharacters in profile URL', () => {
+        const participants = makeParticipants([
+            {id: 'a', name: 'Alice'},
+            {id: 'b', name: 'Bob', profileUrl: 'https://example.com/a)b[x](y'},
+        ]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'b'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain(
+            'Profil: https://example.com/a\\)b\\[x\\]\\(y'
+        );
     });
 
     test('handles empty assignments', () => {

--- a/frontend/src/lib/wichteln/export.test.ts
+++ b/frontend/src/lib/wichteln/export.test.ts
@@ -10,7 +10,7 @@ function makeParticipants(
     return overrides.map((o, i) => ({
         id: o.id ?? `id-${i}`,
         name: o.name ?? `Participant ${i}`,
-        steamProfileUrl: o.steamProfileUrl ?? '',
+        profileUrl: o.profileUrl ?? '',
     }));
 }
 
@@ -46,29 +46,41 @@ describe('generateMarkdown', () => {
         expect(result).toContain('**Bob** → **Alice**');
     });
 
-    test('includes receiver Steam URL when available', () => {
+    test('includes receiver profile URL when available', () => {
         const participants = makeParticipants([
             {id: 'a', name: 'Alice'},
-            {id: 'b', name: 'Bob', steamProfileUrl: 'https://steamcommunity.com/id/bob'},
+            {id: 'b', name: 'Bob', profileUrl: 'https://steamcommunity.com/id/bob'},
         ]);
         const assignments: Assignment[] = [
             {giverId: 'a', receiverId: 'b'},
         ];
         const result = generateMarkdown(participants, assignments);
-        expect(result).toContain('Steam: https://steamcommunity.com/id/bob');
+        expect(result).toContain('Profil: https://steamcommunity.com/id/bob');
     });
 
-    test('omits Steam URL when receiver has none', () => {
+    test('includes GOG URL as profile URL', () => {
         const participants = makeParticipants([
             {id: 'a', name: 'Alice'},
-            {id: 'b', name: 'Bob', steamProfileUrl: ''},
+            {id: 'b', name: 'Bob', profileUrl: 'https://www.gog.com/u/e_Lap'},
+        ]);
+        const assignments: Assignment[] = [
+            {giverId: 'a', receiverId: 'b'},
+        ];
+        const result = generateMarkdown(participants, assignments);
+        expect(result).toContain('Profil: https://www.gog.com/u/e_Lap');
+    });
+
+    test('omits profile URL when receiver has none', () => {
+        const participants = makeParticipants([
+            {id: 'a', name: 'Alice'},
+            {id: 'b', name: 'Bob', profileUrl: ''},
         ]);
         const assignments: Assignment[] = [
             {giverId: 'a', receiverId: 'b'},
         ];
         const result = generateMarkdown(participants, assignments);
         expect(result).toContain('**Alice** → **Bob**');
-        expect(result).not.toContain('Steam:');
+        expect(result).not.toContain('Profil:');
     });
 
     test('skips assignment when participant is missing from map', () => {

--- a/frontend/src/lib/wichteln/export.ts
+++ b/frontend/src/lib/wichteln/export.ts
@@ -26,10 +26,10 @@ export function generateMarkdown(
         const giver = participantMap.get(assignment.giverId);
         const receiver = participantMap.get(assignment.receiverId);
         if (giver && receiver) {
-            const steamInfo = receiver.steamProfileUrl
-                ? ` (Steam: ${receiver.steamProfileUrl})`
+            const profileInfo = receiver.profileUrl
+                ? ` (Profil: ${receiver.profileUrl})`
                 : '';
-            lines.push(`- **${giver.name}** → **${receiver.name}**${steamInfo}`);
+            lines.push(`- **${giver.name}** → **${receiver.name}**${profileInfo}`);
         }
     }
 

--- a/frontend/src/lib/wichteln/export.ts
+++ b/frontend/src/lib/wichteln/export.ts
@@ -1,0 +1,54 @@
+import {type Participant, type Assignment} from '@/app/apps/wichteln/types';
+
+export function generateMarkdown(
+    participants: Participant[],
+    assignments: Assignment[]
+): string {
+    const participantMap = new Map(participants.map((p) => [p.id, p]));
+
+    const lines: string[] = [];
+    lines.push('# Wichteln Ergebnisse');
+    lines.push('');
+    lines.push(
+        `Erstellt am: ${new Date().toLocaleDateString('de-DE', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        })}`
+    );
+    lines.push('');
+    lines.push('## Zuordnungen');
+    lines.push('');
+
+    for (const assignment of assignments) {
+        const giver = participantMap.get(assignment.giverId);
+        const receiver = participantMap.get(assignment.receiverId);
+        if (giver && receiver) {
+            const steamInfo = giver.steamProfileUrl
+                ? ` (Steam: ${giver.steamProfileUrl})`
+                : '';
+            lines.push(`- **${giver.name}**${steamInfo} → **${receiver.name}**`);
+        }
+    }
+
+    lines.push('');
+    return lines.join('\n');
+}
+
+export function downloadMarkdown(
+    participants: Participant[],
+    assignments: Assignment[]
+): void {
+    const markdown = generateMarkdown(participants, assignments);
+    const blob = new Blob([markdown], {type: 'text/markdown;charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `wichteln-${new Date().toISOString().slice(0, 10)}.md`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+}

--- a/frontend/src/lib/wichteln/export.ts
+++ b/frontend/src/lib/wichteln/export.ts
@@ -26,10 +26,10 @@ export function generateMarkdown(
         const giver = participantMap.get(assignment.giverId);
         const receiver = participantMap.get(assignment.receiverId);
         if (giver && receiver) {
-            const steamInfo = giver.steamProfileUrl
-                ? ` (Steam: ${giver.steamProfileUrl})`
+            const steamInfo = receiver.steamProfileUrl
+                ? ` (Steam: ${receiver.steamProfileUrl})`
                 : '';
-            lines.push(`- **${giver.name}**${steamInfo} → **${receiver.name}**`);
+            lines.push(`- **${giver.name}** → **${receiver.name}**${steamInfo}`);
         }
     }
 

--- a/frontend/src/lib/wichteln/export.ts
+++ b/frontend/src/lib/wichteln/export.ts
@@ -1,5 +1,11 @@
 import {type Participant, type Assignment} from '@/app/apps/wichteln/types';
 
+function escapeMarkdown(value: string): string {
+    return value
+        .replace(/\r?\n/g, ' ')
+        .replace(/[\\`*_{}[\]()#+\-.!]/g, '\\$&');
+}
+
 export function generateMarkdown(
     participants: Participant[],
     assignments: Assignment[]
@@ -29,7 +35,9 @@ export function generateMarkdown(
             const profileInfo = receiver.profileUrl
                 ? ` (Profil: ${receiver.profileUrl})`
                 : '';
-            lines.push(`- **${giver.name}** → **${receiver.name}**${profileInfo}`);
+            lines.push(
+                `- **${escapeMarkdown(giver.name)}** → **${escapeMarkdown(receiver.name)}**${profileInfo}`
+            );
         }
     }
 

--- a/frontend/src/lib/wichteln/export.ts
+++ b/frontend/src/lib/wichteln/export.ts
@@ -3,7 +3,7 @@ import {type Participant, type Assignment} from '@/app/apps/wichteln/types';
 function escapeMarkdown(value: string): string {
     return value
         .replace(/\r?\n/g, ' ')
-        .replace(/[\\`*_{}[\]()#+\-.!]/g, '\\$&');
+        .replace(/[\\`*_{}[\]()#+\-!]/g, '\\$&');
 }
 
 export function generateMarkdown(
@@ -33,7 +33,7 @@ export function generateMarkdown(
         const receiver = participantMap.get(assignment.receiverId);
         if (giver && receiver) {
             const profileInfo = receiver.profileUrl
-                ? ` (Profil: ${receiver.profileUrl})`
+                ? ` (Profil: ${escapeMarkdown(receiver.profileUrl)})`
                 : '';
             lines.push(
                 `- **${escapeMarkdown(giver.name)}** → **${escapeMarkdown(receiver.name)}**${profileInfo}`

--- a/frontend/src/lib/wichteln/shuffle.test.ts
+++ b/frontend/src/lib/wichteln/shuffle.test.ts
@@ -8,7 +8,7 @@ function makeParticipants(names: string[]): Participant[] {
     return names.map((name) => ({
         id: crypto.randomUUID(),
         name,
-        steamProfileUrl: '',
+        profileUrl: '',
     }));
 }
 

--- a/frontend/src/lib/wichteln/shuffle.test.ts
+++ b/frontend/src/lib/wichteln/shuffle.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, test} from 'vitest';
+
+import {shuffleAndAssign} from './shuffle';
+
+import {type Participant} from '@/app/apps/wichteln/types';
+
+function makeParticipants(names: string[]): Participant[] {
+    return names.map((name) => ({
+        id: crypto.randomUUID(),
+        name,
+        steamProfileUrl: '',
+    }));
+}
+
+describe('shuffleAndAssign', () => {
+    test('returns correct number of assignments', () => {
+        const participants = makeParticipants(['Alice', 'Bob', 'Charlie']);
+        const result = shuffleAndAssign(participants);
+        expect(result).toHaveLength(3);
+    });
+
+    test('creates a circular derangement (no self-assignments)', () => {
+        const participants = makeParticipants(['Alice', 'Bob', 'Charlie', 'Diana']);
+        const result = shuffleAndAssign(participants);
+        for (const a of result) {
+            expect(a.giverId).not.toBe(a.receiverId);
+        }
+    });
+
+    test('every participant appears exactly once as giver', () => {
+        const participants = makeParticipants(['Alice', 'Bob', 'Charlie']);
+        const result = shuffleAndAssign(participants);
+        const giverIds = result.map((a) => a.giverId).sort();
+        const expectedIds = participants.map((p) => p.id).sort();
+        expect(giverIds).toEqual(expectedIds);
+    });
+
+    test('every participant appears exactly once as receiver', () => {
+        const participants = makeParticipants(['Alice', 'Bob', 'Charlie']);
+        const result = shuffleAndAssign(participants);
+        const receiverIds = result.map((a) => a.receiverId).sort();
+        const expectedIds = participants.map((p) => p.id).sort();
+        expect(receiverIds).toEqual(expectedIds);
+    });
+
+    test('creates a single cycle (no disjoint subsets)', () => {
+        const participants = makeParticipants(['Alice', 'Bob', 'Charlie', 'Diana']);
+        const result = shuffleAndAssign(participants);
+
+        const assignmentMap = new Map(result.map((a) => [a.giverId, a.receiverId]));
+        const visited = new Set<string>();
+        let current = participants[0].id;
+        for (let i = 0; i < participants.length; i++) {
+            visited.add(current);
+            const next = assignmentMap.get(current);
+            expect(next).toBeDefined();
+            current = next!;
+        }
+        expect(visited.size).toBe(participants.length);
+    });
+
+    test('throws for less than 2 participants', () => {
+        expect(() => shuffleAndAssign(makeParticipants([]))).toThrow(
+            'Need at least 2 participants'
+        );
+        expect(() => shuffleAndAssign(makeParticipants(['Alice']))).toThrow(
+            'Need at least 2 participants'
+        );
+    });
+
+    test('handles 2 participants correctly', () => {
+        const participants = makeParticipants(['Alice', 'Bob']);
+        const result = shuffleAndAssign(participants);
+        expect(result).toHaveLength(2);
+        expect(result[0].giverId).toBe(result[1].receiverId);
+        expect(result[0].receiverId).toBe(result[1].giverId);
+    });
+
+    test('produces different results across runs (probabilistic)', () => {
+        const participants = makeParticipants(['Alice', 'Bob', 'Charlie', 'Diana']);
+        const results = new Set<string>();
+        for (let i = 0; i < 20; i++) {
+            const result = shuffleAndAssign(participants);
+            results.add(JSON.stringify(result));
+        }
+        expect(results.size).toBeGreaterThan(1);
+    });
+});

--- a/frontend/src/lib/wichteln/shuffle.ts
+++ b/frontend/src/lib/wichteln/shuffle.ts
@@ -1,0 +1,41 @@
+import {type Participant, type Assignment} from '@/app/apps/wichteln/types';
+
+function fisherYatesShuffle<T>(array: T[]): T[] {
+    const shuffled = [...array];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+}
+
+function isValidDerangement(assignments: Assignment[]): boolean {
+    return assignments.every((a) => a.giverId !== a.receiverId);
+}
+
+export function shuffleAndAssign(participants: Participant[]): Assignment[] {
+    if (participants.length < 2) {
+        throw new Error('Need at least 2 participants');
+    }
+
+    const ids = participants.map((p) => p.id);
+    const maxAttempts = 10;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const shuffled = fisherYatesShuffle(ids);
+        const assignments: Assignment[] = [];
+        for (let i = 0; i < shuffled.length; i++) {
+            const nextIndex = (i + 1) % shuffled.length;
+            assignments.push({
+                giverId: shuffled[i],
+                receiverId: shuffled[nextIndex],
+            });
+        }
+
+        if (isValidDerangement(assignments)) {
+            return assignments;
+        }
+    }
+
+    throw new Error('Could not create valid assignments. Try adding more participants.');
+}

--- a/frontend/src/lib/wichteln/validation.test.ts
+++ b/frontend/src/lib/wichteln/validation.test.ts
@@ -1,0 +1,89 @@
+import {describe, expect, test} from 'vitest';
+
+import {validateName, validateSteamUrl, isValidHttpUrl} from './validation';
+
+describe('validateName', () => {
+    test('valid name returns null', () => {
+        expect(validateName('Alice')).toBeNull();
+    });
+
+    test('empty string returns error', () => {
+        expect(validateName('')).toBe('Name darf nicht leer sein');
+    });
+
+    test('whitespace-only returns error', () => {
+        expect(validateName('   ')).toBe('Name darf nicht leer sein');
+    });
+
+    test('single character returns error', () => {
+        expect(validateName('A')).toBe('Name muss mindestens 2 Zeichen lang sein');
+    });
+
+    test('very long name returns error', () => {
+        expect(validateName('A'.repeat(101))).toBe(
+            'Name darf maximal 100 Zeichen lang sein'
+        );
+    });
+
+    test('100 characters is valid', () => {
+        expect(validateName('A'.repeat(100))).toBeNull();
+    });
+
+    test('trims whitespace before validation', () => {
+        expect(validateName('  Alice  ')).toBeNull();
+    });
+});
+
+describe('validateSteamUrl', () => {
+    test('empty string returns null (optional field)', () => {
+        expect(validateSteamUrl('')).toBeNull();
+    });
+
+    test('whitespace-only returns null', () => {
+        expect(validateSteamUrl('   ')).toBeNull();
+    });
+
+    test('valid steamcommunity URL returns null', () => {
+        expect(validateSteamUrl('https://steamcommunity.com/id/testuser')).toBeNull();
+    });
+
+    test('valid steampowered URL returns null', () => {
+        expect(validateSteamUrl('https://store.steampowered.com/app/12345')).toBeNull();
+    });
+
+    test('invalid URL returns error', () => {
+        const result = validateSteamUrl('not-a-url');
+        expect(result).toBe('Bitte gib eine gültige URL ein (z.B. https://steamcommunity.com/id/...)');
+    });
+
+    test('non-Steam URL returns error', () => {
+        const result = validateSteamUrl('https://example.com/profile');
+        expect(result).toBe('Bitte gib eine gültige Steam-URL ein');
+    });
+
+    test('www.steamcommunity.com is valid', () => {
+        expect(validateSteamUrl('https://www.steamcommunity.com/id/user')).toBeNull();
+    });
+
+    test('www.steampowered.com is valid', () => {
+        expect(validateSteamUrl('https://www.steampowered.com/app/123')).toBeNull();
+    });
+});
+
+describe('isValidHttpUrl', () => {
+    test('valid https URL returns true', () => {
+        expect(isValidHttpUrl('https://example.com')).toBe(true);
+    });
+
+    test('valid http URL returns true', () => {
+        expect(isValidHttpUrl('http://example.com')).toBe(true);
+    });
+
+    test('invalid string returns false', () => {
+        expect(isValidHttpUrl('not-a-url')).toBe(false);
+    });
+
+    test('empty string returns false', () => {
+        expect(isValidHttpUrl('')).toBe(false);
+    });
+});

--- a/frontend/src/lib/wichteln/validation.test.ts
+++ b/frontend/src/lib/wichteln/validation.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from 'vitest';
 
-import {validateName, validateSteamUrl, isValidHttpUrl} from './validation';
+import {validateName, validateProfileUrl, isValidHttpUrl} from './validation';
 
 describe('validateName', () => {
     test('valid name returns null', () => {
@@ -34,39 +34,55 @@ describe('validateName', () => {
     });
 });
 
-describe('validateSteamUrl', () => {
+describe('validateProfileUrl', () => {
     test('empty string returns null (optional field)', () => {
-        expect(validateSteamUrl('')).toBeNull();
+        expect(validateProfileUrl('')).toBeNull();
     });
 
     test('whitespace-only returns null', () => {
-        expect(validateSteamUrl('   ')).toBeNull();
+        expect(validateProfileUrl('   ')).toBeNull();
     });
 
     test('valid steamcommunity URL returns null', () => {
-        expect(validateSteamUrl('https://steamcommunity.com/id/testuser')).toBeNull();
+        expect(validateProfileUrl('https://steamcommunity.com/id/testuser')).toBeNull();
     });
 
     test('valid steampowered URL returns null', () => {
-        expect(validateSteamUrl('https://store.steampowered.com/app/12345')).toBeNull();
+        expect(validateProfileUrl('https://store.steampowered.com/app/12345')).toBeNull();
+    });
+
+    test('valid GOG URL returns null', () => {
+        expect(validateProfileUrl('https://www.gog.com/u/e_Lap')).toBeNull();
+    });
+
+    test('valid GOG URL without www returns null', () => {
+        expect(validateProfileUrl('https://gog.com/u/e_Lap')).toBeNull();
     });
 
     test('invalid URL returns error', () => {
-        const result = validateSteamUrl('not-a-url');
-        expect(result).toBe('Bitte gib eine gültige URL ein (z.B. https://steamcommunity.com/id/...)');
+        const result = validateProfileUrl('not-a-url');
+        expect(result).toBe(
+            'Bitte gib eine gültige URL ein (z.B. https://steamcommunity.com/id/... oder https://www.gog.com/u/...)'
+        );
     });
 
-    test('non-Steam URL returns error', () => {
-        const result = validateSteamUrl('https://example.com/profile');
-        expect(result).toBe('Bitte gib eine gültige Steam-URL ein');
+    test('non-Steam/GOG URL returns error', () => {
+        const result = validateProfileUrl('https://example.com/profile');
+        expect(result).toBe('Bitte gib eine gültige Steam- oder GOG-URL ein');
     });
 
-    test('www.steamcommunity.com is valid', () => {
-        expect(validateSteamUrl('https://www.steamcommunity.com/id/user')).toBeNull();
+    test('rejects non-http protocols', () => {
+        const result = validateProfileUrl('javascript:alert(1)');
+        expect(result).toBe(
+            'Bitte gib eine gültige URL ein, die mit http:// oder https:// beginnt'
+        );
     });
 
-    test('www.steampowered.com is valid', () => {
-        expect(validateSteamUrl('https://www.steampowered.com/app/123')).toBeNull();
+    test('rejects ftp protocol', () => {
+        const result = validateProfileUrl('ftp://steamcommunity.com/id/test');
+        expect(result).toBe(
+            'Bitte gib eine gültige URL ein, die mit http:// oder https:// beginnt'
+        );
     });
 });
 

--- a/frontend/src/lib/wichteln/validation.ts
+++ b/frontend/src/lib/wichteln/validation.ts
@@ -1,0 +1,43 @@
+const STEAM_VALID_HOSTNAMES = [
+    'steamcommunity.com',
+    'www.steamcommunity.com',
+    'steampowered.com',
+    'www.steampowered.com',
+    'store.steampowered.com',
+];
+
+export function validateName(name: string): string | null {
+    const trimmed = name.trim();
+    if (trimmed.length === 0) return 'Name darf nicht leer sein';
+    if (trimmed.length < 2) return 'Name muss mindestens 2 Zeichen lang sein';
+    if (trimmed.length > 100) return 'Name darf maximal 100 Zeichen lang sein';
+    return null;
+}
+
+export function validateSteamUrl(url: string): string | null {
+    const trimmed = url.trim();
+    if (trimmed.length === 0) return null;
+
+    try {
+        const parsed = new URL(trimmed);
+        const isValid = STEAM_VALID_HOSTNAMES.some((hostname) =>
+            parsed.hostname === hostname ||
+            parsed.hostname.endsWith(`.${hostname}`)
+        );
+        if (!isValid) {
+            return 'Bitte gib eine gültige Steam-URL ein';
+        }
+        return null;
+    } catch {
+        return 'Bitte gib eine gültige URL ein (z.B. https://steamcommunity.com/id/...)';
+    }
+}
+
+export function isValidHttpUrl(value: string): boolean {
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}

--- a/frontend/src/lib/wichteln/validation.ts
+++ b/frontend/src/lib/wichteln/validation.ts
@@ -1,9 +1,11 @@
-const STEAM_VALID_HOSTNAMES = [
+const VALID_HOSTNAMES = [
     'steamcommunity.com',
     'www.steamcommunity.com',
     'steampowered.com',
     'www.steampowered.com',
     'store.steampowered.com',
+    'gog.com',
+    'www.gog.com',
 ];
 
 export function validateName(name: string): string | null {
@@ -14,22 +16,25 @@ export function validateName(name: string): string | null {
     return null;
 }
 
-export function validateSteamUrl(url: string): string | null {
+export function validateProfileUrl(url: string): string | null {
     const trimmed = url.trim();
     if (trimmed.length === 0) return null;
 
     try {
         const parsed = new URL(trimmed);
-        const isValid = STEAM_VALID_HOSTNAMES.some((hostname) =>
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return 'Bitte gib eine gültige URL ein, die mit http:// oder https:// beginnt';
+        }
+        const isValid = VALID_HOSTNAMES.some((hostname) =>
             parsed.hostname === hostname ||
             parsed.hostname.endsWith(`.${hostname}`)
         );
         if (!isValid) {
-            return 'Bitte gib eine gültige Steam-URL ein';
+            return 'Bitte gib eine gültige Steam- oder GOG-URL ein';
         }
         return null;
     } catch {
-        return 'Bitte gib eine gültige URL ein (z.B. https://steamcommunity.com/id/...)';
+        return 'Bitte gib eine gültige URL ein (z.B. https://steamcommunity.com/id/... oder https://www.gog.com/u/...)';
     }
 }
 


### PR DESCRIPTION
Closes #359

## Summary

Adds a new `/apps` route section with a landing page and a `/apps/wichteln` game for organizing Steam Wichtel rounds.

## Changes

### New Files

| File | Purpose |
|------|---------|
| `frontend/app/apps/page.tsx` | Apps landing page (Server Component with metadata) |
| `frontend/app/apps/page.module.css` | Landing page grid layout |
| `frontend/app/apps/wichteln/page.tsx` | Wichteln game page ('use client') with full state management |
| `frontend/app/apps/wichteln/page.module.css` | Wichteln styles, responsive |
| `frontend/app/apps/wichteln/types.ts` | Participant, Assignment, WichtelnState types |
| `frontend/src/lib/storage/localStorage.ts` | SSR-safe localStorage get/set/remove with in-memory fallback |
| `frontend/src/lib/wichteln/shuffle.ts` | Fisher-Yates shuffle with circular derangement |
| `frontend/src/lib/wichteln/export.ts` | Markdown export with Blob download |
| `frontend/src/lib/wichteln/validation.ts` | Name and Steam URL validators |
| `frontend/src/components/Button/Button.tsx` | Reusable Button (primary/secondary, loading) |
| `frontend/src/components/Button/Button.module.css` | Button styles |
| `frontend/src/components/Input/Input.tsx` | Reusable Input with error display |
| `frontend/src/components/Input/Input.module.css` | Input styles |

### Modified Files

| File | Change |
|------|--------|
| `frontend/src/lib/routes.ts` | Added `apps` and `wichteln` routes |

## Features

- **Participant management**: Add, edit, and delete participants with name + optional Steam profile URL
- **Shuffle**: Fisher-Yates shuffle with circular derangement (A→B→C→A), prevents self-assignments
- **Persistence**: All state saved to localStorage with SSR-safe utilities and in-memory fallback
- **Export**: Download assignments as Markdown file with names and Steam URLs
- **Validation**: Name length/empty checks, Steam URL hostname validation
- **UI**: Responsive design matching existing CSS patterns, keyboard navigation, empty states, error handling
- **Hydration**: Uses same `useSyncExternalStore` pattern as ThemeToggle for SSR safety

## Verification

- ✅ `pnpm run test:run` — 592 tests pass
- ✅ `npx tsc --noEmit` — zero errors
- ✅ `pnpm run build` — succeeds, both `/apps` and `/apps/wichteln` are static routes